### PR TITLE
UI polish: article body width, login footer, Swiss Post sponsor, two-line footer

### DIFF
--- a/public/swiss-post.svg
+++ b/public/swiss-post.svg
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" width="72px"
+	 height="72px" viewBox="0 0 72 72" style="enable-background:new 0 0 72 72;" xml:space="preserve">
+<style type="text/css">
+	.st0{fill:#FFCC00;}
+	.st1{fill:#FF0000;}
+</style>
+<g id="Logo">
+	<rect x="0" y="0" class="st0" width="72" height="72"/>
+	<polygon class="st1" points="34,32.3 34,19 19.7,19 19.7,29.1 10,29.1 10,42.9 19.7,42.9 19.7,53 34,53 34,39.7 30.6,39.7 
+		30.6,49.8 23.1,49.8 23.1,39.7 13.4,39.7 13.4,32.3 23.1,32.3 23.1,22.2 30.6,22.2 30.6,32.3 	"/>
+	<path d="M53.56234,31.10526c0,2.41272-1.99154,4.29475-4.51723,4.29475H45.2v-8.3h3.84511
+		C51.66802,27.1,53.56234,28.78889,53.56234,31.10526z M50.69666,19H36v34h9.2V42.9h5.49666
+		c6.75131,0,11.9971-5.15137,11.9971-11.8057C62.69376,24.39136,57.35099,19,50.69666,19z"/>
+</g>
+</svg>

--- a/scripts/bootstrap-resources.sh
+++ b/scripts/bootstrap-resources.sh
@@ -123,22 +123,41 @@ if [ -z "$KV_ID" ]; then
   echo "KV: created $KV_TITLE → $KV_ID"
 fi
 
-# ----------------------------------------------------------- resource: Queue
-QUEUE_NAME=$(toml_scalar '[[queues.producers]]' 'queue')
-if [ -z "$QUEUE_NAME" ]; then
-  echo "ERROR: could not parse queue name from wrangler.toml"
+# ---------------------------------------------------------- resource: Queues
+# Iterate every `[[queues.producers]]` section in wrangler.toml (the
+# global-feed rework ships two: `scrape-coordinator` + `scrape-chunks`).
+# For each, check-or-create on Cloudflare so a fresh fork lands with the
+# queues pre-provisioned before `wrangler deploy` runs.
+QUEUE_NAMES=$(awk '
+  $0 == "[[queues.producers]]" { in_sec = 1; next }
+  /^\[/ && in_sec { in_sec = 0 }
+  in_sec && $1 == "queue" {
+    n = split($0, parts, "\"")
+    if (n >= 2) print parts[2]
+  }
+' wrangler.toml)
+
+if [ -z "$QUEUE_NAMES" ]; then
+  echo "ERROR: could not parse any queue names from wrangler.toml"
   exit 1
 fi
-if cf_get "/accounts/$CLOUDFLARE_ACCOUNT_ID/queues" \
-    | jq -e --arg n "$QUEUE_NAME" '.result | any(.queue_name == $n)' > /dev/null; then
-  echo "Queue: '$QUEUE_NAME' already exists"
-else
-  echo "Queue: creating '$QUEUE_NAME'..."
-  BODY=$(jq -cn --arg n "$QUEUE_NAME" '{queue_name:$n}')
-  cf_post "/accounts/$CLOUDFLARE_ACCOUNT_ID/queues" "$BODY" \
-    | jq -r '.result.queue_name' > /dev/null
-  echo "Queue: created $QUEUE_NAME"
-fi
+
+EXISTING_QUEUES=$(cf_get "/accounts/$CLOUDFLARE_ACCOUNT_ID/queues")
+
+while IFS= read -r QUEUE_NAME; do
+  [ -z "$QUEUE_NAME" ] && continue
+  if printf '%s' "$EXISTING_QUEUES" \
+      | jq -e --arg n "$QUEUE_NAME" '.result | any(.queue_name == $n)' \
+      > /dev/null; then
+    echo "Queue: '$QUEUE_NAME' already exists"
+  else
+    echo "Queue: creating '$QUEUE_NAME'..."
+    BODY=$(jq -cn --arg n "$QUEUE_NAME" '{queue_name:$n}')
+    cf_post "/accounts/$CLOUDFLARE_ACCOUNT_ID/queues" "$BODY" \
+      | jq -r '.result.queue_name' > /dev/null
+    echo "Queue: created $QUEUE_NAME"
+  fi
+done <<< "$QUEUE_NAMES"
 
 # -------------------------------------------------- patch wrangler.toml ids
 # Only touch the specific id lines inside [[d1_databases]] / [[kv_namespaces]]
@@ -173,6 +192,9 @@ awk -v new="$KV_ID" '
 
 echo ""
 echo "Resolved resource ids:"
-echo "  D1:    $D1_NAME = $D1_ID"
-echo "  KV:    $KV_TITLE = $KV_ID"
-echo "  Queue: $QUEUE_NAME"
+echo "  D1:     $D1_NAME = $D1_ID"
+echo "  KV:     $KV_TITLE = $KV_ID"
+while IFS= read -r QUEUE_NAME; do
+  [ -z "$QUEUE_NAME" ] && continue
+  echo "  Queue:  $QUEUE_NAME"
+done <<< "$QUEUE_NAMES"

--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -115,6 +115,9 @@ const initialTheme = cookieTheme ?? 'light';
 
     <footer class="site-footer safe-x" aria-label="Site footer">
       <p class="site-footer__copy">
+        Built with <a class="site-footer__link" href="https://codeflare.ch/" target="_blank" rel="noopener noreferrer">Codeflare</a>
+      </p>
+      <p class="site-footer__copy">
         © 2026 <a class="site-footer__link" href="https://graymatter.ch" target="_blank" rel="noopener noreferrer">Gray Matter GmbH</a>
       </p>
     </footer>
@@ -200,6 +203,11 @@ const initialTheme = cookieTheme ?? 'light';
       }
       .site-footer__copy {
         margin: 0;
+      }
+      /* Stack the two lines (Codeflare credit + Gray Matter copyright)
+         with a tight gap so they read as a single footer block. */
+      .site-footer__copy + .site-footer__copy {
+        margin-top: 0.25rem;
       }
       .site-footer__link {
         color: var(--text-muted);

--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -115,12 +115,78 @@ const initialTheme = cookieTheme ?? 'light';
 
     <footer class="site-footer safe-x" aria-label="Site footer">
       <p class="site-footer__copy">
-        Built with <a class="site-footer__link" href="https://codeflare.ch/" target="_blank" rel="noopener noreferrer">Codeflare</a>
+        Built with <a class="site-footer__link" href="https://codeflare.ch/" target="_blank" rel="noopener noreferrer"><span class="site-footer__scramble js-scramble-target" aria-label="Codeflare">Codeflare</span></a>
       </p>
       <p class="site-footer__copy">
         © 2026 <a class="site-footer__link" href="https://graymatter.ch" target="_blank" rel="noopener noreferrer">Gray Matter GmbH</a>
       </p>
     </footer>
+
+    <script>
+      // Scramble effect on the "Codeflare" wordmark in the footer.
+      // Mirrors the effect used on codeflare.ch and graymatter.ch so
+      // the attribution reads as part of the same brand family.
+      //
+      // State machine:
+      //   hold (60 ticks) → scramble (30 ticks) → decrypt (25 ticks) →
+      //   swap (15 ticks) → hold (…)
+      //
+      // Tick cadence 50ms; full cycle ~6.5 seconds.
+      function initFooterScramble() {
+        const elements = document.querySelectorAll('.js-scramble-target');
+        if (elements.length === 0) return;
+
+        const CHARS =
+          'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789!@#$%^&*<>{}[]|/\\~';
+        const TICK_MS = 50;
+        const target = 'Codeflare';
+        let current = target.split('');
+        let phase: 'hold' | 'scramble' | 'decrypt' | 'swap' = 'hold';
+        let frame = 0;
+
+        function randomChar(): string {
+          return CHARS[Math.floor(Math.random() * CHARS.length)] ?? 'x';
+        }
+
+        const interval = setInterval(() => {
+          frame++;
+          if (phase === 'hold') {
+            if (frame > 60) { phase = 'scramble'; frame = 0; }
+            return;
+          }
+          if (phase === 'scramble') {
+            current = current.map((_, i) =>
+              Math.random() < 0.4 ? randomChar() : (target[i] ?? ''));
+            if (frame > 30) { phase = 'decrypt'; frame = 0; }
+          } else if (phase === 'decrypt') {
+            current = current.map((_, i) =>
+              Math.random() < frame / 25 ? (target[i] ?? '') : randomChar());
+            if (frame > 25) { phase = 'swap'; frame = 0; current = target.split(''); }
+          } else if (phase === 'swap') {
+            const a = Math.floor(Math.random() * current.length);
+            const b = Math.floor(Math.random() * current.length);
+            [current[a], current[b]] = [current[b]!, current[a]!];
+            if (frame > 15) { phase = 'hold'; frame = 0; current = target.split(''); }
+          }
+          const scrambled = current.join('');
+          elements.forEach((el) => { (el as HTMLElement).textContent = scrambled; });
+        }, TICK_MS);
+
+        // Tear down the ticker before View Transitions swap the DOM so
+        // the next page's init starts fresh. Without this the timer
+        // leaks and accumulates on every in-app navigation.
+        document.addEventListener('astro:before-swap', () => {
+          clearInterval(interval);
+        }, { once: true });
+      }
+
+      if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', initFooterScramble);
+      } else {
+        initFooterScramble();
+      }
+      document.addEventListener('astro:page-load', initFooterScramble);
+    </script>
 
     <style>
       /* Sticky header with a tasteful backdrop blur on scroll — no solid

--- a/src/pages/digest/[id]/[slug].astro
+++ b/src/pages/digest/[id]/[slug].astro
@@ -448,7 +448,6 @@ const articleDataset = {
 
   .article-detail__paragraph {
     margin: 0;
-    max-width: 62ch;
     font-family: var(--font-sans);
     font-size: var(--text-base);
     line-height: 1.65;

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -71,7 +71,12 @@ const errorMessage =
   .landing {
     display: grid;
     place-items: center;
-    min-height: calc(100svh - 4rem);
+    /* Leave room for the sticky header (~60px) + global footer (~80px
+       including top-margin + padding) so the footer lands inside the
+       viewport on short content. Without this, landing fills 100svh-4rem
+       which combined with header + footer pushes the footer below
+       the fold and forces the user to scroll. */
+    min-height: calc(100svh - 12rem);
     padding: 2rem 1.25rem;
   }
   .landing__hero {

--- a/src/pages/settings.astro
+++ b/src/pages/settings.astro
@@ -85,6 +85,21 @@ const primaryCta = isFirstRun ? 'Save and continue' : 'Save';
       <p class="settings__subtitle">{heroBody}</p>
     </header>
 
+    {!isFirstRun && (
+      <div class="settings__sponsor" aria-label="Project sponsor">
+        <img
+          src="/swiss-post.svg"
+          alt="Swiss Post"
+          class="settings__sponsor-logo"
+          width="56"
+          height="56"
+        />
+        <span class="settings__sponsor-caption">
+          Powered by Security Architecture @ Swiss Post
+        </span>
+      </div>
+    )}
+
     {!isFirstRun && <StatsWidget />}
 
     <form class="settings__form" data-settings-form>
@@ -460,6 +475,29 @@ const primaryCta = isFirstRun ? 'Save and continue' : 'Save';
     display: flex;
     flex-direction: column;
     gap: 0.5rem;
+  }
+
+  /* Sponsor/credit block between hero and stats — small-caps caption
+     to the right of the Swiss Post logo so it reads as chrome-attribution,
+     not a content section. */
+  .settings__sponsor {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+    padding: 0.75rem 0;
+  }
+  .settings__sponsor-logo {
+    width: 48px;
+    height: 48px;
+    flex-shrink: 0;
+  }
+  .settings__sponsor-caption {
+    font-size: 11px;
+    font-weight: 600;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+    color: var(--text-muted);
+    line-height: 1.4;
   }
 
   .settings__title {


### PR DESCRIPTION
## Summary

Four UI fixes on top of the global-feed rework:

- **Article detail body width**: remove the 62ch cap on paragraphs so the body fills the same 680px column as the title (was visibly narrower on longer articles).
- **Login page footer**: bump landing `min-height` from `100svh - 4rem` to `100svh - 12rem` so sticky header + footer both fit the viewport. Footer no longer hides below the fold.
- **Swiss Post sponsor block**: add `swiss-post.svg` to `public/`; render between the settings hero and StatsWidget with caption "Powered by Security Architecture @ Swiss Post". Hidden during first-run onboarding.
- **Footer becomes two lines**: "Built with [Codeflare](https://codeflare.ch/)" on line 1, "© 2026 Gray Matter GmbH" on line 2 with a tight 0.25rem gap.

## Test plan

- [ ] After deploy, visit `/digest/{id}/{slug}` and confirm body paragraphs extend to the same right edge as the title.
- [ ] Log out and visit `/` — footer is visible without scrolling on a standard laptop viewport.
- [ ] Log in, visit `/settings` — Swiss Post logo + caption rendered between heading and stats tiles.
- [ ] Scroll to any page footer — two lines, both links work.