### PR TITLE
ci: devx + Dependabot target=develop + setup-node v6

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,11 @@ version: 2
 updates:
   - package-ecosystem: npm
     directory: /
+    # main is PR-only (protected). develop is the working branch,
+    # and all merges to main go through a PR develop -> main. Point
+    # Dependabot at develop so its PRs land in the same review +
+    # CI cycle as every other change.
+    target-branch: develop
     schedule:
       interval: weekly
       day: monday
@@ -35,6 +40,7 @@ updates:
 
   - package-ecosystem: github-actions
     directory: /
+    target-branch: develop
     schedule:
       interval: weekly
       day: monday

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -30,7 +30,7 @@ jobs:
       contents: read
       security-events: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -14,13 +14,6 @@ concurrency:
 
 permissions: read-all
 
-# Opt every JS action in this workflow into Node.js 24. actions/checkout
-# and actions/setup-node at v4 still ship a Node-20 bundle; the flag
-# below forces the runner to execute them under Node 24. Without it,
-# GitHub logs a deprecation warning until 2026-06-02 and then hard-fails.
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
-
 jobs:
   analyze:
     name: Analyze
@@ -32,7 +25,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: '22'
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,11 +21,6 @@ concurrency:
 permissions:
   contents: read
 
-# Opt actions/checkout@v6 + actions/setup-node@v4 into the runner's
-# Node.js 24 interpreter so the Node-20 deprecation warning goes away.
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
-
 jobs:
   deploy:
     name: Deploy to Cloudflare Workers
@@ -41,7 +36,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: '22'
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,7 +21,7 @@ concurrency:
 permissions:
   contents: read
 
-# Opt actions/checkout@v4 + actions/setup-node@v4 into the runner's
+# Opt actions/checkout@v6 + actions/setup-node@v4 into the runner's
 # Node.js 24 interpreter so the Node-20 deprecation warning goes away.
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
@@ -39,7 +39,7 @@ jobs:
     environment: production
     needs: []
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -99,7 +99,23 @@ jobs:
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
         run: |
           set -o pipefail
-          npx --yes wrangler deploy 2>&1 | tee deploy.log
+          # Wrangler's esbuild pass re-bundles dist/_worker.js/ and
+          # emits "Duplicate key" warnings for legitimate HTML5 entity
+          # aliases in Astro's bundled `entities` dependency (nrarr,
+          # acute, euro, Vdash). They're harmless — later-declared
+          # keys win in the resulting object — but they flood the
+          # deploy log. Filter the whole warning block (header line
+          # + context up to the next blank line) out of the tee'd
+          # output; the raw log still lands in deploy.log for
+          # reference. We also drop any leftover "The original key"
+          # context lines so partial blocks don't bleed through.
+          npx --yes wrangler deploy 2>&1 | tee deploy.log | \
+            awk '
+              /^▲ \[WARNING\] Duplicate key ".*" in object literal \[duplicate-object-key\]/ { skip=1; next }
+              skip && /^$/ { skip=0; next }
+              skip { next }
+              { print }
+            '
           # Extract the workers.dev URL wrangler prints on success.
           WORKER_URL=$(grep -oE 'https://[^ ]+\.workers\.dev' deploy.log | head -n1 || true)
           echo "worker_url=$WORKER_URL" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -28,7 +28,7 @@ jobs:
       contents: read
       actions: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           persist-credentials: false
         env:

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -31,8 +31,6 @@ jobs:
       - uses: actions/checkout@v6
         with:
           persist-credentials: false
-        env:
-          FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
 
       - name: Run Scorecard
         uses: ossf/scorecard-action@v2.4.3
@@ -47,12 +45,8 @@ jobs:
           name: SARIF file
           path: results.sarif
           retention-days: 5
-        env:
-          FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
 
       - name: Upload to code-scanning
         uses: github/codeql-action/upload-sarif@v4
         with:
           sarif_file: results.sarif
-        env:
-          FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -42,7 +42,7 @@ jobs:
           publish_results: true
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: SARIF file
           path: results.sarif

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -35,7 +35,7 @@ jobs:
           FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
 
       - name: Run Scorecard
-        uses: ossf/scorecard-action@v2.4.0
+        uses: ossf/scorecard-action@v2.4.3
         with:
           results_file: results.sarif
           results_format: sarif

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,13 +2,13 @@ name: PR Checks
 # Fires on:
 #   - push to develop (fast feedback on work-in-progress)
 #   - push to main (post-merge regression gate; deploy fires only on green)
-#   - pull_request targeting main (pre-merge gate)
+#   - pull_request targeting main OR develop (pre-merge gate)
 #   - workflow_dispatch (manual re-run)
 on:
   push:
     branches: [main, develop]
   pull_request:
-    branches: [main]
+    branches: [main, develop]
   workflow_dispatch:
 
 concurrency:
@@ -18,11 +18,6 @@ concurrency:
 permissions:
   contents: read
 
-# Opt actions/checkout@v6 + actions/setup-node@v4 into the runner's
-# Node.js 24 interpreter so the Node-20 deprecation warning goes away.
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
-
 jobs:
   test:
     name: Test suite
@@ -31,7 +26,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: '22'
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ concurrency:
 permissions:
   contents: read
 
-# Opt actions/checkout@v4 + actions/setup-node@v4 into the runner's
+# Opt actions/checkout@v6 + actions/setup-node@v4 into the runner's
 # Node.js 24 interpreter so the Node-20 deprecation warning goes away.
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
@@ -29,7 +29,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: actions/setup-node@v4
         with:

--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ Also included, because why not: **PWA-installable, dark mode out of the box, an 
 
 The internet became a dark-pattern theme park where every ride ends at the gift shop. News Digest is one ride that just runs.
 
+*Full disclosure: the footer says **"Built with Codeflare · © Gray Matter"**. Both of those are me. I'm allowed to sign the bottom of my own work in six words of quiet grey text. That's not a sponsorship, it's a signature. If anyone wants to call this out as an ad, I'll refund them the $0 they paid.*
+
 ## Features
 
 - **One global LLM run, every user benefits.** GPT-OSS-120B summarises the whole pool every 4 hours, billed to my Cloudflare account, not yours, and way cheaper than the coffee I was going to drink while ignoring Hacker News anyway.

--- a/sdd/constraints.md
+++ b/sdd/constraints.md
@@ -6,7 +6,7 @@ Cross-cutting architectural and technology decisions that apply to every domain.
 
 | Layer | Choice | Rationale |
 |-------|--------|-----------|
-| Framework | Astro 5 on Cloudflare Workers | Server-rendered Astro with the `astrojs/cloudflare` adapter; islands for interactive UI only where needed. |
+| Framework | Astro on Cloudflare Workers | Server-rendered Astro with the `astrojs/cloudflare` adapter; islands for interactive UI only where needed. |
 | Database | Cloudflare D1 | Strong consistency for users, digests, articles, pending discoveries. |
 | Cache / KV | Cloudflare KV | Eventually-consistent edge-distributed cache for discovered sources, headlines, source health. |
 | Job queue | Cloudflare Queues | Single `digest-jobs` queue absorbs thundering herds; consumer runs with isolate-per-message concurrency. |

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -30,6 +30,14 @@ export default defineConfig({
     include: ['tests/**/*.test.ts'],
     // Suppress structured-log noise from src/lib/log.ts during tests.
     // Real failures still print via vitest's own reporter.
-    silent: true
+    silent: true,
+    // Compact per-file output in CI — a dot per passing test, a full
+    // stack for failing tests. The default reporter prints every
+    // single test name + file which floods the GitHub Actions log
+    // (800+ test lines on every push). dot mode keeps the summary
+    // + failure diff but drops the per-test noise.
+    reporters: process.env['CI'] === 'true' ? ['dot'] : ['default'],
+    // Drop the per-task timing noise in CI — still shown in local runs.
+    printConsoleTrace: false
   }
 });


### PR DESCRIPTION
## Summary

Seven commits on `develop` collected after PR #12:

- **Dependabot** target branch → `develop` so it flows through the same review path as every other change.
- **Dependabot merges**: `actions/checkout` 4 → 6, `actions/upload-artifact` 4 → 7, `ossf/scorecard-action` 2.4.0 → 2.4.3.
- **`actions/setup-node` 4 → 6** across test / deploy / codeql; dropped the `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24` compatibility env in all three workflows (no more Node 20 deprecation warning).
- **PR Checks trigger** now covers pull_request to `[main, develop]` so feature-branch PRs get gated.
- **Vitest reporter** switches to `dot` in CI (was flooding 800+ lines per push); local runs keep `default`.
- **Deploy log filter** skips esbuild `Duplicate key` warning blocks (legit HTML-entity aliases from Astro's bundled `entities`; flooding the deploy log with ~40 lines per push).
- **README footer disclosure** — self-aware aside about the "Built with Codeflare © Gray Matter" footer not contradicting the "no brought to you by" claim.
- **Spec**: `sdd/constraints.md` no longer pins an Astro major (spec-reviewer auto-fix; versions live in `package.json`).

## Test plan

- [ ] PR Checks green on this PR.
- [ ] On merge, deploy auto-triggers via `workflow_run`.
- [ ] Deploy log no longer shows Node 20 deprecation or Duplicate key warnings.
- [ ] CI test output is significantly shorter (dot reporter).

## Not included

- Astro 6 / @astrojs/cloudflare 13 / TypeScript 6 (PR #13) — closed, ecosystem peers aren't ready (see closed-PR comment chain for blockers).