### PR TITLE
fix(reading): bind history tag click to the strip, retry scroll restore until it sticks

### DIFF
--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -288,21 +288,36 @@ const initialTheme = cookieTheme ?? 'light';
           sessionStorage.setItem(KEY(), String(window.scrollY));
         } catch { /* storage quota / disabled — nothing to do */ }
       }
+      // Retry-based restore: the naive "single rAF after page-load"
+      // race-loses against image-heavy pages on mobile, where the
+      // layout height isn't established until lazy images have
+      // decoded. If we call scrollTo(0, 1200) on a page that's only
+      // 600px tall, the browser clamps to 600px and the real target
+      // is lost. We retry on each frame for up to a second, stopping
+      // as soon as scrollY matches target (within 2px) or the user
+      // scrolls manually (which cancels the attempt to avoid a jump
+      // under their finger).
       function restoreScroll(): void {
         try {
           const raw = sessionStorage.getItem(KEY());
           if (raw === null) return;
-          const y = Number.parseInt(raw, 10);
-          if (!Number.isFinite(y) || y <= 0) return;
-          // Defer so page-specific init (filter hydration, tag-
-          // chip DOM reorder, etc.) has settled before we scroll.
-          // A single rAF is enough in practice; two-rAF would be
-          // belt-and-suspenders if layout depends on images loading.
-          requestAnimationFrame(() => {
-            requestAnimationFrame(() => {
-              window.scrollTo(0, y);
-            });
-          });
+          const target = Number.parseInt(raw, 10);
+          if (!Number.isFinite(target) || target <= 0) return;
+          const started = performance.now();
+          const DURATION_MS = 1000;
+          let cancelled = false;
+          const cancel = (): void => { cancelled = true; };
+          window.addEventListener('wheel', cancel, { once: true, passive: true });
+          window.addEventListener('touchmove', cancel, { once: true, passive: true });
+          const tick = (): void => {
+            if (cancelled) return;
+            const now = performance.now();
+            window.scrollTo(0, target);
+            if (Math.abs(window.scrollY - target) <= 2) return;
+            if (now - started > DURATION_MS) return;
+            requestAnimationFrame(tick);
+          };
+          requestAnimationFrame(tick);
         } catch { /* ditto */ }
       }
       if (document.documentElement.dataset['scrollRestoreBound'] !== '1') {

--- a/src/pages/history.astro
+++ b/src/pages/history.astro
@@ -412,27 +412,20 @@ function formatCostUsd(value: number | null | undefined): string {
       input.addEventListener('input', apply);
     }
 
-    // Tag chip click handlers — toggle is-selected and re-run the
-    // combined filter. Delegate from `document` rather than binding
-    // to the strip element: (a) it survives View-Transition DOM
-    // replacements without a rebind step, (b) a document-level
-    // listener keeps working even when a client-added chip gets
-    // appended after the strip was first scanned. Scoped to clicks
-    // inside a [data-tag-strip-wrap] that's ON THIS PAGE by checking
-    // `[data-history-search]` exists — this prevents the handler
-    // from firing on the dashboard (which has its own click
-    // handler) when the user navigates via ClientRouter.
-    const historyClickHandler = (e: MouseEvent): void => {
-      // Scope by pathname — the listener is bound to `document` once
-      // per session and survives View-Transition navigations, so a
-      // DOM-selector check ('[data-history-search]') would fire on any
-      // page that happens to share the selector. pathname is the
-      // cheapest, least-entangled guard.
-      if (window.location.pathname !== '/history') return;
+    // Tag chip click handler — toggle is-selected and re-run the
+    // combined filter. Bound DIRECTLY to the strip element (not via
+    // document-level delegation). Earlier attempts to delegate from
+    // `document` survived in theory but kept breaking in practice on
+    // SPA return — most likely because the handler's closure over
+    // `apply` / `input` got stale even with teardown in place. Binding
+    // to the strip itself ties the handler's lifetime to the DOM node
+    // it acts on: when the node is swapped out by ClientRouter, its
+    // listeners go with it, no explicit teardown needed.
+    const stripWrap = document.querySelector<HTMLElement>('[data-tag-strip-wrap]');
+    const stripClickHandler = (e: Event): void => {
       const target = e.target;
       if (!(target instanceof Element)) return;
-      if (target.closest('[data-tag-strip-wrap]') === null) return;
-      // Remove (×) takes precedence — it's inside the chip.
+      // Remove (×) takes precedence — it sits inside the chip.
       const removeHit = target.closest<HTMLElement>('[data-tag-remove]');
       if (removeHit !== null) {
         e.preventDefault();
@@ -450,24 +443,16 @@ function formatCostUsd(value: number | null | undefined): string {
       chip.classList.toggle('is-selected', !wasSelected);
       chip.setAttribute('aria-pressed', wasSelected ? 'false' : 'true');
       if (!wasSelected) {
-        // Pin the just-selected chip to scroll-position 0 of the
-        // (mobile-scrollable) strip so it stays visible without the
-        // user having to scroll back to find it. insertBefore rather
-        // than prepend — the Workers + DOM type overlap in this
-        // repo's tsconfig gives prepend an ambiguous signature that
-        // astro check rejects.
         const thisStrip = chip.closest<HTMLElement>('[data-tag-strip]');
-        if (thisStrip !== null) thisStrip.insertBefore(chip, thisStrip.firstChild);
+        if (thisStrip !== null) {
+          thisStrip.insertBefore(chip, thisStrip.firstChild);
+        }
       }
       apply();
     };
-    // Bind per-init and remove in the teardown returned below. Binding
-    // once with a flag would freeze the handler's closure over the DOM
-    // captured on first visit; the next time the user returns to
-    // /history via ClientRouter, the new DOM is live but the old
-    // handler still calls the detached `apply` → chip clicks silently
-    // do nothing until the user hard-reloads.
-    document.addEventListener('click', historyClickHandler);
+    if (stripWrap !== null) {
+      stripWrap.addEventListener('click', stripClickHandler);
+    }
 
     // Hydrate from URL on load: restore q + tag selections so that
     // navigating back to /history?q=foo&tags=a,b brings the user to
@@ -508,7 +493,9 @@ function formatCostUsd(value: number | null | undefined): string {
       if (input !== null) {
         input.removeEventListener('input', apply);
       }
-      document.removeEventListener('click', historyClickHandler);
+      if (stripWrap !== null) {
+        stripWrap.removeEventListener('click', stripClickHandler);
+      }
     };
   }
 

--- a/tests/history/page.test.ts
+++ b/tests/history/page.test.ts
@@ -109,23 +109,24 @@ describe('history.astro — REQ-HIST-001', () => {
     );
   });
 
-  it('REQ-HIST-001: tag-chip click handler is bound and torn down per-init so ClientRouter return does not leave a stale closure', () => {
-    // Regression: with a documentElement-level `historyTagStripBound`
-    // flag, the document click listener was installed once on first
-    // visit and froze its closure over the initial DOM. Returning to
-    // /history via View Transitions replaced the DOM but the old
-    // handler kept calling the detached `apply()` — tag clicks did
-    // nothing until the user hard-reloaded. The fix binds the handler
-    // inside initHistorySearch and removes it in the returned
-    // teardown so every reinit gets a fresh closure over live DOM.
+  it('REQ-HIST-001: tag-chip click handler binds directly to the strip wrap so ClientRouter return keeps the listener live', () => {
+    // Regression: delegating the click from `document` with a
+    // pathname guard + closure-captured `apply` kept breaking on
+    // SPA-return to /history — tag clicks silently did nothing until
+    // the user hard-reloaded. The dashboard binds directly to
+    // `[data-tag-strip]` and has never had this issue. History now
+    // mirrors that proven pattern: bind inside initHistorySearch onto
+    // `[data-tag-strip-wrap]`, remove it in the teardown. When
+    // ClientRouter swaps the DOM node out, its listeners go with it.
     expect(historyPageSource).not.toMatch(/historyTagStripBound/);
-    // Bind lives inside initHistorySearch, not behind a documentElement flag.
-    expect(historyPageSource).toMatch(
-      /document\.addEventListener\(\s*'click',\s*historyClickHandler/,
+    expect(historyPageSource).not.toMatch(
+      /document\.addEventListener\(\s*'click',/,
     );
-    // Teardown returned by initHistorySearch removes the same handler.
     expect(historyPageSource).toMatch(
-      /document\.removeEventListener\(\s*'click',\s*historyClickHandler/,
+      /stripWrap\.addEventListener\(\s*'click',\s*stripClickHandler/,
+    );
+    expect(historyPageSource).toMatch(
+      /stripWrap\.removeEventListener\(\s*'click',\s*stripClickHandler/,
     );
   });
 


### PR DESCRIPTION
## Summary

Two bugs the user keeps hitting on mobile, SPA navigation:

### 1. /history tag chips unclickable until hard reload

Previous attempt used document-level delegation with a pathname guard and bind-per-init teardown. Correct in theory but kept losing the handler's `apply` closure in practice. Switched to the pattern the dashboard has always used: bind click directly to `[data-tag-strip-wrap]` inside `initHistorySearch`. When ClientRouter swaps the DOM node, its listeners go with it — no pathname guard, no teardown race.

### 2. Scroll position resets on back-nav from article detail

Double-rAF restore raced lazy image decoding on mobile — `scrollTo` clamped to a short-page height before images grew it, then the target was lost. New loop retries `scrollTo(0, target)` each frame for up to 1000ms, stops on `Math.abs(scrollY - target) <= 2` OR on user wheel/touchmove.

## Test plan

- [ ] CI green
- [ ] After merge + deploy: on mobile, navigate from landing → /history → tap tag chip — chip selects without reload
- [ ] After merge + deploy: on mobile, scroll dashboard, tap article → tap back — land at previous scroll position
- [ ] Same test on /history (click card, back, scroll preserved)