### PR TITLE
fix: four SPA + data-fresh bugs the user has been hitting repeatedly

### DIFF
--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -282,7 +282,18 @@ const initialTheme = cookieTheme ?? 'light';
         sessionStorage is keyed by pathname so forward navs to a
         page the user hasn't visited yet scroll to 0 cleanly. */}
     <script>
-      const KEY = (): string => `scroll:${window.location.pathname}`;
+      // Track the path of the page whose scroll position we are
+      // currently managing in a module-scoped variable, NOT in
+      // `window.location.pathname`. Astro's ClientRouter calls
+      // history.pushState BEFORE firing `astro:before-swap`, so by
+      // the time saveScroll runs, `window.location.pathname` has
+      // already flipped to the destination URL — we were saving
+      // /digest's scroll under the detail page's key, and on return
+      // reading `scroll:/digest` found nothing. currentPath is
+      // updated only when restoreScroll completes so saveScroll
+      // always writes under the page the user is leaving.
+      let currentPath = window.location.pathname;
+      const KEY = (): string => `scroll:${currentPath}`;
       function saveScroll(): void {
         try {
           sessionStorage.setItem(KEY(), String(window.scrollY));
@@ -298,11 +309,16 @@ const initialTheme = cookieTheme ?? 'light';
       // scrolls manually (which cancels the attempt to avoid a jump
       // under their finger).
       function restoreScroll(): void {
+        // Advance currentPath to the page we're now on. Any future
+        // saveScroll calls before the next navigation will correctly
+        // key against this page, not the next destination.
+        currentPath = window.location.pathname;
         try {
           const raw = sessionStorage.getItem(KEY());
           if (raw === null) return;
           const target = Number.parseInt(raw, 10);
-          if (!Number.isFinite(target) || target <= 0) return;
+          if (!Number.isFinite(target) || target < 0) return;
+          if (target === 0) return;
           const started = performance.now();
           const DURATION_MS = 1000;
           let cancelled = false;
@@ -330,6 +346,16 @@ const initialTheme = cookieTheme ?? 'light';
         document.addEventListener('astro:before-swap', saveScroll);
         window.addEventListener('pagehide', saveScroll);
         document.addEventListener('astro:page-load', restoreScroll);
+        // bfcache restore on iOS Safari: `astro:page-load` does NOT
+        // fire when the browser back-navigates from an external link
+        // and the page is served from bfcache. `pageshow` with
+        // `persisted === true` is the signal for that path — without
+        // it, Safari sees `scrollRestoration = 'manual'` and leaves
+        // the scroll at 0. restoreScroll is idempotent and safe to
+        // run again; it will read the saved scrollY and tick.
+        window.addEventListener('pageshow', (e) => {
+          if (e.persisted) restoreScroll();
+        });
         restoreScroll();
       }
     </script>

--- a/src/pages/digest.astro
+++ b/src/pages/digest.astro
@@ -348,6 +348,15 @@ const todayLocalDate = localDateInTz(Math.floor(Date.now() / 1000), userTz);
   }
 
   function init(): void {
+    // The astro:page-load listener below is bound to `document` and
+    // survives ClientRouter navigations — meaning it ALSO fires when
+    // the user lands on /history (which shares <TagStrip /> with
+    // this page). Without a page-marker guard, init() would
+    // re-attach a click handler to [data-tag-strip] on /history,
+    // stomping on /history's own handler and silently cancelling
+    // every chip toggle. data-digest-page is only present on this
+    // route, so the check keeps /digest's bindings scoped to it.
+    if (document.querySelector('[data-digest-page]') === null) return;
     wireCountdown();
     wireOfflineBanner();
     wireTagStrip();

--- a/src/pages/history.astro
+++ b/src/pages/history.astro
@@ -499,35 +499,48 @@ function formatCostUsd(value: number | null | undefined): string {
     };
   }
 
-  /** POST /api/tags to add a tag to the session user's hashtag list,
-   *  then reload so both the tag strip and per-tag counts reflect
-   *  the new state. Reload (instead of surgical DOM patching) keeps
-   *  history and dashboard add-tag flows behaving identically. */
-  async function addTag(tag: string): Promise<void> {
+  /** Read every tag currently rendered in the strip — the source of
+   *  truth for the user's active hashtag list on this page. Used by
+   *  addTag/removeTag to POST the NEW FULL list to /api/tags (which
+   *  expects a replacement array, not a per-tag add/remove). Earlier
+   *  versions here posted `{tag}` (singular) and DELETE'd a
+   *  non-existent /api/tags/:tag route, so removals looked
+   *  successful client-side but never persisted. */
+  function currentStripTags(): string[] {
+    const strip = document.querySelector<HTMLElement>('[data-tag-strip]');
+    if (strip === null) return [];
+    return Array.from(strip.querySelectorAll<HTMLElement>('[data-tag-chip]'))
+      .map((chip) => chip.dataset['tag'] ?? '')
+      .filter((t) => t !== '');
+  }
+
+  async function saveTagsList(tags: string[]): Promise<boolean> {
     try {
       const res = await fetch('/api/tags', {
         method: 'POST',
         credentials: 'same-origin',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ tag }),
+        body: JSON.stringify({ tags }),
       });
-      if (res.ok) window.location.reload();
+      return res.ok;
     } catch {
-      // leave the input untouched so the user can retry
+      return false;
     }
   }
 
-  /** DELETE /api/tags/<tag> + reload. */
+  /** Append `tag` to the user's list via POST /api/tags, then reload
+   *  so the strip and per-tag counts reflect the new state. */
+  async function addTag(tag: string): Promise<void> {
+    const next = currentStripTags();
+    if (!next.includes(tag)) next.push(tag);
+    if (await saveTagsList(next)) window.location.reload();
+  }
+
+  /** Remove `tag` from the user's list. Posts the filtered array so
+   *  the server UPDATE writes the authoritative new state. */
   async function removeTag(tag: string): Promise<void> {
-    try {
-      const res = await fetch(`/api/tags/${encodeURIComponent(tag)}`, {
-        method: 'DELETE',
-        credentials: 'same-origin',
-      });
-      if (res.ok) window.location.reload();
-    } catch {
-      // swallow — user can retry
-    }
+    const next = currentStripTags().filter((t) => t !== tag);
+    if (await saveTagsList(next)) window.location.reload();
   }
 
   /** Wire the "+ add" pill: reveal input, submit on Enter / blur,

--- a/src/pages/settings.astro
+++ b/src/pages/settings.astro
@@ -82,7 +82,16 @@ if (typeof user.hashtags_json === 'string' && user.hashtags_json !== '') {
   try {
     const parsed = JSON.parse(user.hashtags_json) as unknown;
     if (Array.isArray(parsed)) {
-      userHashtags = parsed.filter((v): v is string => typeof v === 'string');
+      // Normalise on read so legacy rows that were stored before the
+      // write-path normalisation landed (mixed case, leading `#`,
+      // stray whitespace) still match DEFAULT_HASHTAGS set-membership
+      // comparisons below. Without this, showDelete stayed false for
+      // an account seeded with `['#ai', 'AI', ...]` because
+      // userHashtagSet.has('ai') returned false on case mismatch.
+      userHashtags = parsed
+        .filter((v): v is string => typeof v === 'string')
+        .map((t) => t.trim().toLowerCase().replace(/^#/, ''))
+        .filter((t) => t !== '');
     }
   } catch {
     userHashtags = [];

--- a/src/queue/scrape-coordinator.ts
+++ b/src/queue/scrape-coordinator.ts
@@ -258,6 +258,37 @@ export async function runCoordinator(
   const survivors = clusters.filter(
     (c) => !existing.has(c.primary.canonical_url),
   );
+  // Re-freshen ingested_at for articles that are STILL IN the live
+  // feed emission. Without this, a scrape tick that finds nothing
+  // net-new leaves the dashboard order frozen on the previous tick's
+  // ingestions — so a 4-hour-old article that's still actively
+  // trending in its source feed looks "stale" to the user even
+  // though it's freshly confirmed as current. Bumping ingested_at
+  // lets sort-by-ingest surface whatever the feeds consider current
+  // right now, not whatever happened to be ingested first. Batched
+  // in groups of 100 to stay inside D1's parameter-count budget.
+  const reSeenUrls = clusters
+    .map((c) => c.primary.canonical_url)
+    .filter((url) => existing.has(url));
+  if (reSeenUrls.length > 0) {
+    const nowSec = Math.floor(Date.now() / 1000);
+    const REFRESH_BATCH = 100;
+    for (let i = 0; i < reSeenUrls.length; i += REFRESH_BATCH) {
+      const slice = reSeenUrls.slice(i, i + REFRESH_BATCH);
+      const placeholders = slice.map((_, j) => `?${j + 2}`).join(', ');
+      await env.DB
+        .prepare(
+          `UPDATE articles SET ingested_at = ?1 WHERE canonical_url IN (${placeholders})`,
+        )
+        .bind(nowSec, ...slice)
+        .run();
+    }
+    log('info', 'digest.generation', {
+      status: 'coordinator_refreshed_existing',
+      scrape_run_id,
+      re_seen: reSeenUrls.length,
+    });
+  }
 
   // --- Step 6: Empty-pool guard — close the run immediately -----------
   if (survivors.length === 0) {


### PR DESCRIPTION
## Summary

Closes four bugs in one PR after consulting external LLMs for root-cause diagnosis.

### 1. /history tag chips dead after SPA return (commit 72d0e64)
`/digest`'s `astro:page-load` listener fires on every ClientRouter navigation. With no page-marker guard, its `init()` ran on `/history` and wired a SECOND click handler to `[data-tag-strip]` — two handlers toggled `is-selected` and cancelled each other out. Added `[data-digest-page]` scope check at the top of `init()`.

### 2. Scroll resets on mobile back-nav (commit 72d0e64)
`saveScroll` read `window.location.pathname` inside `astro:before-swap`, but Astro calls `pushState` BEFORE firing the event. `/digest`'s scrollY got written under the destination URL's key; on return, `scroll:/digest` was empty. Fix: module-scoped `currentPath`, updated only inside `restoreScroll`. Also added `pageshow(persisted)` for iOS bfcache back-nav.

### 3. Force-refresh didn't re-freshen the dashboard (commit 6d96b0b)
Coordinator filtered re-seen canonical_urls before enqueuing chunks, so existing articles' `ingested_at` stayed frozen. A live-feed article ingested 4 hours ago could pin to the top across a whole tick despite being confirmed current. Bulk `UPDATE articles SET ingested_at = now WHERE canonical_url IN (...)` at Step 5, batched in groups of 100.

### 4. History add/remove broken + Delete-initial-tags hidden (commit 6d96b0b)
- `history.astro`'s `addTag`/`removeTag` posted malformed bodies (`{tag}` singular) and hit a non-existent DELETE route. Replaced with the dashboard's proven `POST /api/tags {tags: [...]}` full-list pattern.
- `settings.astro` didn't normalise `userHashtags` on read, so legacy rows with `'#ai'` or `'AI'` broke the `showDeleteInitialsButton` set-membership check. Normalised via trim → lowercase → strip leading #.

## Test plan

- [ ] CI green
- [ ] Deploy green
- [ ] On mobile: /landing → /history, tap chip → filters apply first tap (no reload needed)
- [ ] On mobile: scroll /digest, tap card, back → scroll position preserved
- [ ] Settings page: Delete initial tags button visible for accounts with both defaults + customs
- [ ] Next scrape tick: re-seen live-feed articles move to top of dashboard