### PR TITLE
test(pipeline): silence CodeQL false-positive on test-only URL membership check

### DIFF
--- a/tests/pipeline/coordinator.test.ts
+++ b/tests/pipeline/coordinator.test.ts
@@ -373,7 +373,11 @@ describe('scrape-coordinator — REQ-PIPE-001', () => {
       (r) =>
         r.sql.includes('UPDATE articles') &&
         r.sql.includes('ingested_at') &&
-        (r.params as unknown[]).includes(reSeenUrl),
+        // Array-element equality check (NOT a URL-substring check).
+        // Using `.some(p => p === url)` instead of `.includes(url)`
+        // so CodeQL's js/incomplete-url-substring-sanitization rule
+        // doesn't false-positive on a test-only membership assertion.
+        (r.params as unknown[]).some((p) => p === reSeenUrl),
     );
     expect(update).toBeDefined();
     expect(typeof (update!.params as unknown[])[0]).toBe('number');


### PR DESCRIPTION
## Summary

CodeQL flagged `tests/pipeline/coordinator.test.ts` for `js/incomplete-url-substring-sanitization` on the line

```
(r.params as unknown[]).includes(reSeenUrl)
```

That rule fires whenever a URL-shaped string is passed to `.includes()` — it can't tell a string-substring check (genuinely vulnerable: `url.includes('mydomain.com')` fails on `mydomain.com.attacker.com`) from an array-element membership check (totally fine: this test asserting the SQL parameter array contained the URL). 

Rewrote as `(r.params as unknown[]).some((p) => p === reSeenUrl)` — identical semantics, no rule match, no global suppression comment needed.

## Test plan
- [ ] CI green
- [ ] CodeQL alert resolves on merge