### PR TITLE
fix(reading): pre-filter incoming DOM in astro:before-swap — fifth time's the charm

### DIFF
--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -359,6 +359,60 @@ const initialTheme = cookieTheme ?? 'light';
           requestAnimationFrame(tick);
         } catch { /* ditto */ }
       }
+      // astro:before-swap listener that PRE-APPLIES the tag filter to
+      // the incoming `event.newDocument` before the body swap. Load-
+      // bearing for scroll + animation correctness when `?tags=` is
+      // active in the URL on /digest or /history: without this, the
+      // new body arrives from the server with every card visible, the
+      // ViewTransitions API captures the incoming snapshot against
+      // that unfiltered DOM, Astro's own scrollTo(historyState.scrollY)
+      // lands on the unfiltered layout, and only AFTER astro:page-load
+      // does the page script's applyFilter() set display:none on
+      // non-matching cards — collapsing the grid AFTER the snapshot +
+      // scroll-restore were committed. Result: browser clamps scroll
+      // to the now-shorter doc and the transition morphs between
+      // incompatible geometries ("animation feels wrong").
+      //
+      // Mutating newDocument during before-swap is supported by the
+      // Astro event type (TransitionBeforeSwapEvent.newDocument is
+      // writable per packages/astro/src/transitions/events.ts) and is
+      // the only place early enough to make the snapshot see the
+      // filtered state.
+      interface BeforeSwapEvent extends Event {
+        newDocument: Document;
+        to: URL;
+      }
+      function preFilterIncomingDocument(e: Event): void {
+        const ev = e as BeforeSwapEvent;
+        const path = ev.to?.pathname ?? '';
+        if (path !== '/digest' && path !== '/history') return;
+        const raw = ev.to.searchParams.get('tags');
+        if (raw === null || raw === '') return;
+        const selected = new Set(
+          raw.split(',').map((t) => t.trim()).filter((t) => t !== ''),
+        );
+        if (selected.size === 0) return;
+        const doc = ev.newDocument;
+        if (doc === undefined) return;
+        doc
+          .querySelectorAll<HTMLElement>('[data-digest-card]')
+          .forEach((card) => {
+            const cardTags = (card.dataset['tags'] ?? '')
+              .split(',')
+              .filter((t) => t !== '');
+            const match = cardTags.some((t) => selected.has(t));
+            if (!match) card.dataset['filterHide'] = '1';
+          });
+        doc
+          .querySelectorAll<HTMLElement>('[data-tag-chip]')
+          .forEach((chip) => {
+            const tag = chip.dataset['tag'];
+            if (tag !== undefined && selected.has(tag)) {
+              chip.classList.add('is-selected');
+              chip.setAttribute('aria-pressed', 'true');
+            }
+          });
+      }
       if (document.documentElement.dataset['scrollRestoreBound'] !== '1') {
         document.documentElement.dataset['scrollRestoreBound'] = '1';
         // Override Astro ClientRouter's scroll-to-top so our per-path
@@ -366,6 +420,7 @@ const initialTheme = cookieTheme ?? 'light';
         if ('scrollRestoration' in window.history) {
           window.history.scrollRestoration = 'manual';
         }
+        document.addEventListener('astro:before-swap', preFilterIncomingDocument);
         document.addEventListener('astro:before-swap', saveScroll);
         window.addEventListener('pagehide', saveScroll);
         document.addEventListener('astro:page-load', restoreScroll);


### PR DESCRIPTION
## Summary

Five fix attempts in, finally caught by three parallel diagnoses (Opus agent + GPT-5 + Gemini all converged on the same root cause with high confidence).

### Root cause

Astro ClientRouter lifecycle:
1. `astro:before-swap` fires (my saveScroll runs)
2. Astro swaps in the **unfiltered** server-rendered body
3. Astro's own `scrollTo(historyState.scrollY)` fires — but on the unfiltered layout
4. `astro:after-swap` fires
5. **View-Transitions captures the incoming snapshot — against the UNFILTERED DOM**
6. animation plays
7. `astro:page-load` fires — only NOW does `applyFilter()` run and set `display: none` on non-matching cards

My four previous fixes (tick loop, ResizeObserver, `pageshow` bfcache, currentPath tracking) all tried to patch this AFTER step 7, but the snapshot and scroll restore were already committed in steps 3 and 5. That's why the animation morphed between incompatible geometries ("feels wrong") and the scroll clamped to 0 on the filtered shorter doc.

### Fix

One new `astro:before-swap` listener in `Base.astro` that mutates `event.newDocument`:
- For `/digest` or `/history` paths with `?tags=` present,
- Pre-applies `data-filter-hide="1"` on non-matching cards and
- Pre-applies `.is-selected` + `aria-pressed="true"` on matching chips.

The body Astro swaps in is already filtered → snapshot + scrollTo + animation all see the final layout → no post-swap reflow.

Kept the 3s rAF tick, ResizeObserver, and `pageshow(persisted)` as a belt for lazy-image layout shifts and bfcache paths. They're idempotent with the new behaviour.

## Test plan

- [ ] CI green
- [ ] On mobile: /digest with tags selected, scroll mid-page, tap article, hit back → land at previous scroll position, view-transition animates smoothly
- [ ] Same flow on /history