### PR TITLE
fix(reading): SSR the tag filter — eliminate the View-Transition snapshot race

### DIFF
--- a/src/components/DigestCard.astro
+++ b/src/components/DigestCard.astro
@@ -46,6 +46,16 @@ interface Props {
    * don't need an ordering churn.
    */
   index?: number;
+  /**
+   * When true, render the card with `data-filter-hide="1"` so the
+   * CSS rule on the card hides it via `display: none`. Used for SSR
+   * of filtered views (dashboard with `?tags=` in URL): emitting the
+   * filter state in the initial HTML avoids the client-side reflow
+   * that wrecked View-Transition snapshots and scroll-restore on
+   * back navigation. Client-side `applyFilter()` still toggles the
+   * same attribute on tag-strip interactions.
+   */
+  filterHide?: boolean;
 }
 
 const {
@@ -59,6 +69,7 @@ const {
   tags = [],
   starred = false,
   index = 0,
+  filterHide = false,
 } = Astro.props;
 
 const href = `/digest/${digestId}/${slug}`;
@@ -103,6 +114,7 @@ const displaySourceName = resolveDisplaySource();
   data-starred={starred ? 'true' : 'false'}
   data-stagger-index={stagger}
   data-tags={tagAttr}
+  data-filter-hide={filterHide ? '1' : undefined}
   style={`--stagger-delay: ${stagger * 40}ms`}
 >
   {/* Anchor wraps ONLY the read area (title + excerpt). The footer

--- a/src/pages/digest.astro
+++ b/src/pages/digest.astro
@@ -97,6 +97,29 @@ const sortedUserTags = [...userTags].sort((a, b) => {
 const rawUserTz = user.tz === '' ? DEFAULT_TZ : user.tz;
 const userTz = isValidTz(rawUserTz) ? rawUserTz : DEFAULT_TZ;
 const todayLocalDate = localDateInTz(Math.floor(Date.now() / 1000), userTz);
+
+// SSR the tag filter from `?tags=` so the initial HTML already
+// reflects the user's active filter. Without this, the server
+// renders every card visible, Astro's ClientRouter swaps that body
+// in on back-nav, the View-Transitions snapshot captures the
+// unfiltered layout, Astro's scrollTo(historyState.scrollY) lands
+// on the wrong content, and the animation morphs between
+// incompatible geometries (outgoing filtered → incoming unfiltered).
+// Emitting the filter state server-side eliminates the entire race.
+// Client-side `applyFilter()` still drives chip-toggle interactions.
+const rawSelectedTags = Astro.url.searchParams.get('tags');
+const selectedTagSet = new Set<string>(
+  typeof rawSelectedTags === 'string' && rawSelectedTags !== ''
+    ? rawSelectedTags
+        .split(',')
+        .map((t) => t.trim().toLowerCase())
+        .filter((t) => t !== '')
+    : [],
+);
+function isCardHidden(articleTags: readonly string[]): boolean {
+  if (selectedTagSet.size === 0) return false;
+  return !articleTags.some((t) => selectedTagSet.has(t));
+}
 ---
 
 <Base title="Today's digest">
@@ -124,7 +147,12 @@ const todayLocalDate = localDateInTz(Math.floor(Date.now() / 1000), userTz);
       to toggle `is-selected`, + add, remove) is wired in the page
       script below against the data-* attributes the component ships.
     */}
-    <TagStrip tags={sortedUserTags} counts={tagCounts} countNoun="articles today" />
+    <TagStrip
+      tags={sortedUserTags}
+      counts={tagCounts}
+      initialSelected={selectedTagSet}
+      countNoun="articles today"
+    />
     <p
       class="tag-strip__nomatch"
       data-tag-nomatch
@@ -171,6 +199,7 @@ const todayLocalDate = localDateInTz(Math.floor(Date.now() / 1000), userTz);
               tags={a.tags}
               starred={a.starred}
               index={i}
+              filterHide={isCardHidden(a.tags)}
             />
           ))}
           {/* REQ-READ-001 AC 5 — slot 30 deep-links to Search &

--- a/src/pages/history.astro
+++ b/src/pages/history.astro
@@ -102,9 +102,36 @@ const isFocused = deepLinkedDay !== null;
 const rawTagsParam = Astro.url.searchParams.get('tags');
 const initialSelectedTagSet = new Set<string>(
   typeof rawTagsParam === 'string' && rawTagsParam !== ''
-    ? rawTagsParam.split(',').map((t) => t.trim()).filter((t) => t !== '')
+    ? rawTagsParam
+        .split(',')
+        .map((t) => t.trim().toLowerCase())
+        .filter((t) => t !== '')
     : [],
 );
+
+// SSR the filtered search-grid when tags are active. Without this,
+// server-rendered HTML shows the day-grouped list and the client-
+// script later hides it and populates the search-grid — which means
+// the View-Transition snapshot and Astro's scrollTo(historyState)
+// both operate on a layout the user never actually sees. On back-
+// nav this broke scroll restoration and the transition animation.
+// Emitting the filtered flat grid server-side eliminates the race.
+// Flatten articles from every day in the 7-day window that match
+// the selected tag set; sort newest-first (matches the dashboard
+// ingested_at DESC contract).
+const isFilteringByTag = initialSelectedTagSet.size > 0 && !isFocused;
+const filteredArticles: WireArticle[] = [];
+if (isFilteringByTag) {
+  for (const day of days) {
+    for (const a of day.articles) {
+      const anyMatch = a.tags.some((t) =>
+        initialSelectedTagSet.has(t.toLowerCase()),
+      );
+      if (anyMatch) filteredArticles.push(a);
+    }
+  }
+  filteredArticles.sort((a, b) => b.published_at - a.published_at);
+}
 
 // User's active hashtags (from the session row) — drives the chip
 // set. Parsing mirrors digest.astro.
@@ -202,11 +229,39 @@ function formatCostUsd(value: number | null | undefined): string {
 
     {/* Flat grid of matching cards — same breakpoint math as
         .digest-page__grid on the dashboard so search results feel
-        like a dashboard view filtered by query. Only visible when
-        the search query has ≥3 characters; the day-grouped list
-        below hides while this is showing. */}
-    <div class="history__search-grid" data-search-grid hidden></div>
-    <p class="history__search-empty" data-search-empty hidden aria-live="polite"></p>
+        like a dashboard view filtered by query. Pre-populated
+        server-side when `?tags=` is active so View-Transition
+        snapshots and scroll restore see the final rendered layout
+        on back-nav. Client script keeps re-rendering this on live
+        chip-toggle and search-input typing. */}
+    <div
+      class="history__search-grid"
+      data-search-grid
+      hidden={!isFilteringByTag}
+    >
+      {isFilteringByTag && filteredArticles.map((a) => (
+        <DigestCard
+          digestId={a.id}
+          articleId={a.id}
+          slug={slugify(a.title)}
+          title={a.title}
+          sourceName={a.primary_source_name}
+          sourceUrl={a.primary_source_url}
+          oneLiner={a.details[0] ?? ''}
+          tags={a.tags}
+        />
+      ))}
+    </div>
+    <p
+      class="history__search-empty"
+      data-search-empty
+      hidden={!(isFilteringByTag && filteredArticles.length === 0)}
+      aria-live="polite"
+    >
+      {isFilteringByTag && filteredArticles.length === 0
+        ? `No articles match ${[...initialSelectedTagSet].map((t) => `#${t}`).join(' ')}.`
+        : ''}
+    </p>
 
     {
       visibleDays.length === 0 ? (
@@ -216,7 +271,7 @@ function formatCostUsd(value: number | null | undefined): string {
             : 'No articles in the last 7 days.'}
         </p>
       ) : (
-        <ol class="history__list" data-history-list>
+        <ol class="history__list" data-history-list hidden={isFilteringByTag}>
           {visibleDays.map((day) => (
             <li class="history__day" data-history-day data-date={day.local_date}>
               <details class="history__details" open={isFocused}>


### PR DESCRIPTION
## Summary

Six fix attempts in, taking the architectural route both GPT-5 and Gemini recommended from the start: **render the filter state server-side**. No client reflow means no snapshot/scroll-restore race.

### The bug

User's exact signature — "works perfectly without tags, broken with tags" — is the textbook shape of "server HTML differs from final rendered state because a client-side script reshapes the DOM after the View-Transition snapshot is captured". On back-nav:

1. Astro swaps in server HTML (unfiltered — all cards / day-grouped list visible)
2. Astro calls `scrollTo(historyState.scrollY)` on that unfiltered layout
3. View-Transitions captures the incoming snapshot
4. Animation plays
5. `astro:page-load` fires → client `applyFilter()` sets `display:none` on non-matching cards / hides day-list / populates search-grid → page collapses → scroll clamps → animation already committed

Fix: emit the filtered state in the server HTML. The initial layout IS the final layout.

### Changes

- `DigestCard.astro` — new `filterHide?: boolean` prop emits `data-filter-hide="1"` on the article. Respected by existing CSS rule.
- `digest.astro` — parse `?tags=` in frontmatter, compute `filterHide` per card, pass to each `<DigestCard>`. Also pre-select chips via `initialSelected` on `<TagStrip>`.
- `history.astro` — when `?tags=` active, flatten matching 7-day articles, pre-populate search-grid server-side, hide day-list via `hidden` attribute.

## Test plan

- [ ] CI green
- [ ] On mobile: /digest with tags selected, scroll mid-page, tap article, back — scroll preserved, animation smooth
- [ ] Same flow on /history
- [ ] Toggling chips client-side still works (client `applyFilter` / `apply` logic untouched)