### PR TITLE
fix(reading): address 3 HIGH findings on the SSR filter commit

### DIFF
--- a/src/components/DigestCard.astro
+++ b/src/components/DigestCard.astro
@@ -56,6 +56,18 @@ interface Props {
    * same attribute on tag-strip interactions.
    */
   filterHide?: boolean;
+  /**
+   * When true, omit the `transition:name` on the card's anchor so
+   * the element does NOT participate in View-Transition shared-
+   * element morphs. Used on /history's server-rendered day-list
+   * when the user has `?tags=` in the URL — that list sits hidden
+   * below an SSR'd flat search-grid whose cards carry the same
+   * per-slug transition names; duplicates abort the transition per
+   * spec. Stripping names from the hidden list eliminates the
+   * collision while keeping the list available for the client's
+   * clone-based filter fallback.
+   */
+  suppressTransition?: boolean;
 }
 
 const {
@@ -70,6 +82,7 @@ const {
   starred = false,
   index = 0,
   filterHide = false,
+  suppressTransition = false,
 } = Astro.props;
 
 const href = `/digest/${digestId}/${slug}`;
@@ -122,6 +135,12 @@ const displaySourceName = resolveDisplaySource();
       receive touch events natively — nesting <button> inside <a>
       flattens to the anchor on mobile Safari/Samsung Browser, which
       is why the star and # were unresponsive to taps. */}
+  {suppressTransition ? (
+    <a class="digest-card__link" href={href} aria-label={title}>
+      <h2 class="digest-card__title">{title}</h2>
+      <p class="digest-card__one-liner">{oneLiner}</p>
+    </a>
+  ) : (
   <a
     class="digest-card__link"
     href={href}
@@ -131,6 +150,7 @@ const displaySourceName = resolveDisplaySource();
     <h2 class="digest-card__title">{title}</h2>
     <p class="digest-card__one-liner">{oneLiner}</p>
   </a>
+  )}
   <footer class="digest-card__footer">
     <span class="digest-card__footer-left">
       {

--- a/src/pages/history.astro
+++ b/src/pages/history.astro
@@ -115,10 +115,11 @@ const initialSelectedTagSet = new Set<string>(
 // the View-Transition snapshot and Astro's scrollTo(historyState)
 // both operate on a layout the user never actually sees. On back-
 // nav this broke scroll restoration and the transition animation.
-// Emitting the filtered flat grid server-side eliminates the race.
-// Flatten articles from every day in the 7-day window that match
-// the selected tag set; sort newest-first (matches the dashboard
-// ingested_at DESC contract).
+// Iterate days + day.articles in the order /api/history returns them
+// (ingested_at DESC per day, days newest-first) — same order the
+// client-side clone path would produce when it walks the day-list
+// DOM. Matching orders makes the client's `apply()` rebuild visually
+// idempotent (the DOM gets wiped and rebuilt but looks identical).
 const isFilteringByTag = initialSelectedTagSet.size > 0 && !isFocused;
 const filteredArticles: WireArticle[] = [];
 if (isFilteringByTag) {
@@ -130,7 +131,6 @@ if (isFilteringByTag) {
       if (anyMatch) filteredArticles.push(a);
     }
   }
-  filteredArticles.sort((a, b) => b.published_at - a.published_at);
 }
 
 // User's active hashtags (from the session row) — drives the chip
@@ -306,6 +306,7 @@ function formatCostUsd(value: number | null | undefined): string {
                           sourceUrl={a.primary_source_url}
                           tags={a.tags}
                           index={i}
+                          suppressTransition={isFilteringByTag}
                         />
                       ))}
                     </div>
@@ -542,7 +543,18 @@ function formatCostUsd(value: number | null | undefined): string {
       }
       needsApply = true;
     }
-    if (needsApply) apply();
+    // Skip the initial apply() when the server already rendered the
+    // filtered search-grid matching the URL's ?tags= state. Without
+    // this, apply() would wipe the SSR'd grid with innerHTML = '' and
+    // rebuild from day-list clones — identical content but the DOM
+    // churn happens mid-animation, flickers, and disrupts the View-
+    // Transition pseudos. Idempotence check: search-grid already has
+    // children AND user hasn't typed a search query.
+    const ssrAlreadyPopulated =
+      searchGrid.children.length > 0 &&
+      searchGrid.hidden === false &&
+      (input === null || input.value.trim() === '');
+    if (needsApply && !ssrAlreadyPopulated) apply();
 
     return () => {
       if (input !== null) {


### PR DESCRIPTION
## Summary

Follow-up to PR #31. Code review caught three interlocking issues that kept the bug partially reproduced:

1. **Duplicate `view-transition-name` collision.** The day-list was hidden via `hidden` attribute but its cards still emitted `transition:name` — duplicating the names on the SSR'd search-grid cards aborted the shared-element morph. Fixed by adding a `suppressTransition` prop to `DigestCard` that omits the `transition:name` on its anchor; passed true on day-list cards when filtering.

2. **SSR sort order diverged from client clone order.** I was sorting `filteredArticles` by `published_at DESC`, but the client's `apply()` walks the day-list DOM in API order (`ingested_at DESC`). When `apply()` wiped and rebuilt, cards came back in a different order — producing the flash I was trying to eliminate. Fixed by dropping the sort and relying on the natural days→articles iteration.

3. **`apply()` wiped the SSR search-grid on every page-load.** Even with correct sort, `innerHTML = ''` + rebuild churns the DOM mid-animation. Fixed by detecting `ssrAlreadyPopulated` (grid has children + empty input) and skipping the initial call.

## Test plan

- [ ] CI green
- [ ] On mobile: /history with tags selected, scroll mid-page, tap article, back — scroll preserved, animation smooth
- [ ] Toggle chip off while on filtered /history — client rebuilds to day-list view cleanly