### PR TITLE
fix(discovery): allow Google News query-RSS fallback for brand/consumer tags

### DIFF
--- a/sdd/changes.md
+++ b/sdd/changes.md
@@ -6,6 +6,7 @@ Each entry is dated, ≤2 sentences, user-facing only. No commit SHAs. No "verif
 
 ## 2026-04-24
 
+- REQ-DISC-001 Intent and AC 3 broadened: the discovery prompt now names a Google News query-RSS fallback for tags without a first-party feed, so consumer/brand tags (ikea, tesla, netflix, etc.) produce at least one working source instead of looping through Re-discover with zero results.
 - REQ-SET-002 AC 8 rewrote the second settings action as "Delete all tags" (not "Delete initial tags"): one click clears the whole list so a user can build a completely custom set without removing 20 default chips one-by-one. Visibility simplified to "show whenever the user has at least one tag".
 - REQ-SET-002 AC 6 raised the hashtag cap from 20 to 25 so a new account, seeded with the 20-default set, has 5 slots of headroom to add custom interests immediately without having to delete a default first.
 - REQ-READ-001 AC 5 and REQ-PIPE-001 AC 4 tightened to describe live-feed freshness: the dashboard now orders by "last feed sighting" (re-seen canonical URLs get re-stamped on every scrape tick) rather than first ingestion, so articles currently trending in any feed bubble to the top on every tick and stale items that have fallen out of every feed sink naturally. "Last feed sighting" is defined in the glossary.

--- a/sdd/discovery.md
+++ b/sdd/discovery.md
@@ -6,14 +6,14 @@ Per-tag feed discovery is LLM-assisted and SSRF-filtered. Settings save queues n
 
 ### REQ-DISC-001: LLM-assisted per-tag feed discovery
 
-**Intent:** When a user adds a hashtag, the system finds authoritative first-party feeds for that tag without requiring a hand-curated catalog.
+**Intent:** When a user adds a hashtag, the system finds working feeds for that tag without requiring a hand-curated catalog — first-party sources when they exist, and a documented third-party aggregator fallback when they don't, so that consumer/brand tags (where no official feed is available) still produce at least one source.
 
 **Applies To:** User
 
 **Acceptance Criteria:**
 1. On settings save, any submitted tag without a `sources:{tag}` KV entry triggers an `INSERT OR IGNORE` into the `pending_discoveries` D1 table keyed by `(user_id, tag)`.
 2. The 5-minute cron picks up to 3 distinct tags from `pending_discoveries` per invocation, ordered by the earliest `added_at` for each tag.
-3. For each tag, a Workers AI call asks for up to 5 authoritative RSS, Atom, or JSON feed URLs; the prompt explicitly instructs the model to return fewer URLs rather than guess.
+3. For each tag, a Workers AI call asks for up to 5 RSS, Atom, or JSON feed URLs. The prompt prefers first-party blogs, release notes, and changelogs where they exist, and names a Google News query-RSS fallback that the model must include for tags without a first-party feed so a consumer/brand tag never returns zero sources. The model is instructed to omit a suggestion only when neither a first-party feed nor the fallback applies.
 4. Each suggested URL is validated: HTTPS-only, passes the SSRF filter (no private ranges, loopback, link-local, Cloudflare internal), HTTP 200, content-type matches the declared kind, parseable, and returns at least one item with a title and URL.
 5. Valid feeds are persisted to `sources:{tag}` as `{ feeds: [{ name, url, kind }], discovered_at }` with no TTL; rows for this tag are deleted from `pending_discoveries` regardless of success.
 

--- a/src/lib/prompts.ts
+++ b/src/lib/prompts.ts
@@ -189,8 +189,9 @@ The object shape is always:
 
 Discovery rules:
 - Only suggest feeds you are highly confident exist at the given URL. Do NOT guess.
-- Prefer official blogs, release notes, and changelogs over third-party news sites.
-- If you are unsure about a feed, omit it — returning fewer correct URLs is better than more guessed URLs.
+- Prefer official blogs, release notes, and changelogs when they exist — they are the strongest signal for a technical topic.
+- When no authoritative first-party feed exists (typical for consumer brands, products, or non-technical topics), include the Google News query-RSS for the topic as a fallback. It always returns a valid RSS 2.0 feed with recent items aggregated across major publishers. Format: {"name":"Google News: <topic>","url":"https://news.google.com/rss/search?q=<topic>&hl=en-US&gl=US&ceid=US:en","kind":"rss"}. Substitute <topic> with the tag itself, URL-encoded if it contains characters outside [a-z0-9-].
+- If you are unsure about a feed AND the Google News fallback also doesn't apply, omit it — returning fewer correct URLs is better than more guessed URLs.
 - "kind" is one of "rss", "atom", or "json".`;
 
 /**

--- a/tests/lib/prompts.test.ts
+++ b/tests/lib/prompts.test.ts
@@ -43,6 +43,17 @@ describe('DISCOVERY_SYSTEM', () => {
   it('REQ-DISC-001: DISCOVERY_SYSTEM requires strict JSON output', () => {
     expect(DISCOVERY_SYSTEM.toLowerCase()).toContain('json');
   });
+
+  it('REQ-DISC-001: DISCOVERY_SYSTEM mentions the Google News query-RSS fallback so consumer/brand tags with no official feed still get a source', () => {
+    // Regression guard: prior prompt told the model to skip
+    // third-party news sites, which emptied discovery for any tag
+    // without an authoritative first-party feed (e.g. #ikea). The
+    // prompt now names Google News query-RSS as the documented
+    // fallback; the model should suggest it when nothing better
+    // exists rather than returning {"feeds": []}.
+    expect(DISCOVERY_SYSTEM).toContain('news.google.com/rss/search');
+    expect(DISCOVERY_SYSTEM.toLowerCase()).toContain('fallback');
+  });
 });
 
 describe('discoveryUserPrompt', () => {


### PR DESCRIPTION
## Summary

Loosens the DISCOVERY_SYSTEM prompt so tags without an authoritative first-party feed (ikea, tesla, netflix, any consumer brand) get a working source instead of an empty `{"feeds": []}`.

### Diagnosis

User added `#ikea`. Discovery ran, LLM returned zero feeds, `discovery_failures:ikea` went to 1, tag sat in `pending_discoveries` for retry. Root cause: the prior prompt said *"Prefer official blogs, release notes, and changelogs over third-party news sites"* — for IKEA (which killed their own RSS in favor of email-only newsletters), the LLM had no valid suggestion and correctly declined to guess.

### Change

One prompt edit. New clause: when no first-party feed exists, the LLM is told to suggest `https://news.google.com/rss/search?q=<topic>&hl=en-US&gl=US&ceid=US:en` as a documented fallback. Preserves the "prefer official" ordering for tech tags (cloudflare, rust, postgres, etc.) where real feeds exist. Regression test added asserting both the URL template and the "fallback" keyword are present in the prompt, so a future prompt tightening can't silently re-regress this.

## Test plan

- [ ] CI green
- [ ] After merge, hit Re-discover on the `#ikea` tag in Settings; discovery fires again and writes `sources:ikea` with the Google News feed.