### PR TITLE
fix(discovery): use messages[] API shape (gpt-oss-120b requires it)

### DIFF
--- a/src/lib/discovery.ts
+++ b/src/lib/discovery.ts
@@ -65,8 +65,19 @@ export async function discoverTag(tag: string, env: Env): Promise<DiscoveredFeed
   const userPrompt = discoveryUserPrompt(tag);
   let payloadRaw: unknown;
   try {
+    // The `@cf/openai/*` family (incl. the current default
+    // gpt-oss-120b) only accepts the chat-completions `messages`
+    // shape — calling with `{prompt: "..."}` returns an
+    // effectively-empty envelope, which shows up as
+    // `empty_llm_response` on every tick. Mirror the chunk consumer
+    // (src/queue/scrape-chunk-consumer.ts) and send role-tagged
+    // messages so the same call shape works across every model in
+    // MODELS.
     const runParams = {
-      prompt: `${DISCOVERY_SYSTEM}\n\n${userPrompt}`,
+      messages: [
+        { role: 'system', content: DISCOVERY_SYSTEM },
+        { role: 'user', content: userPrompt },
+      ],
       ...LLM_PARAMS,
     };
     // Preserve `this` binding — `env.AI.run` may be a method that
@@ -79,9 +90,7 @@ export async function discoverTag(tag: string, env: Env): Promise<DiscoveredFeed
     // Workers AI returns two shapes: flat `{response: "..."}` for
     // Llama/Mistral/Kimi, and the OpenAI envelope
     // `{choices:[{message:{content:"..."}}]}` for every @cf/openai/*
-    // model. extractResponsePayload tolerates both. Without this,
-    // every discovery call on gpt-oss-120b (the current default)
-    // looked like an `empty_llm_response` to the cron loop.
+    // model. extractResponsePayload tolerates both.
     payloadRaw = extractResponsePayload(result);
     if (
       payloadRaw === undefined ||

--- a/tests/discovery/discover-tag.test.ts
+++ b/tests/discovery/discover-tag.test.ts
@@ -177,22 +177,27 @@ describe('discoverTag', () => {
 
     expect(aiRun).toHaveBeenCalledTimes(1);
     const args = aiRun.mock.calls[0]!;
-    const params = args[1] as { prompt?: string };
-    expect(typeof params.prompt).toBe('string');
-    const prompt = params.prompt!;
+    const params = args[1] as {
+      messages?: Array<{ role: string; content: string }>;
+    };
+    expect(Array.isArray(params.messages)).toBe(true);
+    const systemMsg = params.messages!.find((m) => m.role === 'system');
+    const userMsg = params.messages!.find((m) => m.role === 'user');
+    expect(systemMsg).toBeDefined();
+    expect(userMsg).toBeDefined();
 
     // The adversarial text must appear inside a triple-backtick fence in
-    // the user-message portion, not as loose instructions.
+    // the user-message, not as loose instructions.
     const fenceRe = new RegExp(
       '```[\\s\\S]*?' +
         adversarial.replace(/[-/\\^$*+?.()|[\]{}]/g, '\\$&') +
         '[\\s\\S]*?```',
     );
-    expect(prompt).toMatch(fenceRe);
+    expect(userMsg!.content).toMatch(fenceRe);
 
     // The system prompt's non-guessing rule must still be present — the
     // tag did not manage to override it.
-    expect(prompt).toContain(DISCOVERY_SYSTEM);
+    expect(systemMsg!.content).toContain(DISCOVERY_SYSTEM);
   });
 
   it('REQ-DISC-001: returns [] when LLM response is unparseable JSON', async () => {


### PR DESCRIPTION
## Summary

Second root cause on the ikea-tag-has-no-results bug. After merging PR #35's first fix (parse the OpenAI envelope on the way out), discovery still logged \`empty_llm_response\` on every tick. Tailing the worker caught it.

The @cf/openai/* family (including the current default \`gpt-oss-120b\`) only honours the chat-completions input shape. Calling with \`{prompt: "system\\n\\nuser"}\` returns an effectively-empty envelope that \`extractResponsePayload\` correctly classifies as undefined.

The chunk consumer in \`src/queue/scrape-chunk-consumer.ts\` already uses \`messages[]\` across the same \`MODELS\` catalog with no issues, so this aligns discovery with the proven pattern:

\`\`\`ts
messages: [
  { role: "system", content: DISCOVERY_SYSTEM },
  { role: "user",   content: userPrompt },
]
\`\`\`

Adversarial-tag fencing test updated to assert the new shape — system vs user content separation so the fence regex can no longer be satisfied by a stray triple-backtick mention in the system prompt.

## Test plan

- [x] tests/discovery/discover-tag.test.ts updated for messages[] shape, REQ-DISC-005 fence still asserted on user content only.
- [ ] After merge + deploy: re-queue \`#ikea\` and confirm \`sources:ikea\` populates with at least the Google News RSS fallback feed.