### PR TITLE
feat(sources): curate 7 verified AI feeds (incl. Anthropic via Google News)

### DIFF
--- a/src/lib/curated-sources.ts
+++ b/src/lib/curated-sources.ts
@@ -167,6 +167,67 @@ export const CURATED_SOURCES: readonly CuratedSource[] = [
     tags: ['ai'],
   },
   {
+    // Google's official AI blog at blog.google. Distinct from
+    // deepmind-blog above, which is the research-org subsite.
+    slug: 'google-ai-blog',
+    name: 'Google AI Blog',
+    feed_url: 'https://blog.google/technology/ai/rss/',
+    kind: 'rss',
+    tags: ['ai', 'genai'],
+  },
+  {
+    slug: 'microsoft-ai-blog',
+    name: 'Microsoft AI Blog',
+    feed_url: 'https://blogs.microsoft.com/ai/feed/',
+    kind: 'rss',
+    tags: ['ai', 'genai'],
+  },
+  {
+    // Corporate Nvidia blog. Distinct from nvidia-dev-blog above,
+    // which is the developer.nvidia.com subdomain (CUDA/Jetson/etc.).
+    slug: 'nvidia-blog',
+    name: 'Nvidia Blog',
+    feed_url: 'https://blogs.nvidia.com/feed/',
+    kind: 'rss',
+    tags: ['ai', 'genai'],
+  },
+  {
+    slug: 'berkeley-ai-research',
+    name: 'Berkeley AI Research',
+    feed_url: 'https://bair.berkeley.edu/blog/feed.xml',
+    kind: 'rss',
+    tags: ['ai'],
+  },
+  {
+    slug: 'mit-news-ai',
+    name: 'MIT News — AI',
+    feed_url: 'https://news.mit.edu/topic/mitartificial-intelligence2-rss.xml',
+    kind: 'rss',
+    tags: ['ai'],
+  },
+  {
+    // Independent editorial AI publication; longer-form than the
+    // vendor blogs and tends to land critical perspectives.
+    slug: 'the-gradient',
+    name: 'The Gradient',
+    feed_url: 'https://thegradient.pub/rss/',
+    kind: 'rss',
+    tags: ['ai'],
+  },
+  {
+    // Anthropic exposes no public RSS at any standard path (probed
+    // /rss, /feed, /news/rss, /research/rss, /index.xml, etc. — all
+    // 404). Fall back to a Google News query for Claude/Anthropic
+    // coverage from third-party publishers. The same Google News
+    // query-RSS pattern that REQ-DISC-001 already uses for
+    // discovery-fallback on consumer/brand tags.
+    slug: 'google-news-anthropic',
+    name: 'Google News — Anthropic',
+    feed_url: 'https://news.google.com/rss/search?q=anthropic+OR+claude+ai&hl=en-US&gl=US&ceid=US:en',
+    kind: 'rss',
+    tags: ['ai', 'genai'],
+  },
+  {
     slug: 'stripe-blog',
     name: 'Stripe Blog',
     feed_url: 'https://stripe.com/blog/feed.rss',


### PR DESCRIPTION
## Summary

After the bulk re-discover for #ai surfaced only Microsoft AI Blog (the LLM's other suggestions hit our HTTPS+content-type+parseable-RSS validator and most well-known AI publishers either expose RSS at non-obvious paths or don't expose it at all), curated 7 verified feeds operator-side instead of relying on per-tag LLM discovery.

Each URL was probed with a real HTTP GET (8s timeout, browser-like UA) and confirmed to return HTTP 200, serve a valid RSS/Atom content type, and contain at least one parseable item.

| Source | URL | Items in feed |
|---|---|---|
| Google AI Blog | blog.google/technology/ai/rss | 2 |
| Microsoft AI Blog | blogs.microsoft.com/ai/feed | 10 |
| Nvidia Blog (corporate) | blogs.nvidia.com/feed | 18 |
| Berkeley AI Research | bair.berkeley.edu/blog/feed.xml | 10 |
| MIT News — AI | news.mit.edu/topic/mitartificial-intelligence2-rss.xml | 50 |
| The Gradient | thegradient.pub/rss | 11 |
| Google News — Anthropic | news.google.com/rss/search?q=anthropic+OR+claude+ai | varies |

Anthropic exposes no public RSS at any tested standard path (probed `/news/rss`, `/rss`, `/feed`, `/index.xml`, `/research/rss`, etc. — all 404), so the entry is a Google News query-RSS — same fallback pattern REQ-DISC-001 already uses for consumer/brand tags.

## Rejected during verification

- Anthropic, OpenAI Research, Meta AI Blog → 404
- Stanford HAI, Cohere blog → return text/html (validator would reject)

## Test plan

- [x] Existing curated-sources test invariants (≥50 entries, slug uniqueness, every default tag covered, HTTPS-only, valid kind) preserved at 62 entries.
- [ ] Post-deploy: confirm new feeds appear in next coordinator tick logs.