### PR TITLE
docs(readme): Google sign-in + curated AI sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Keeping up with tech news was a part-time job I didn't sign up for, didn't get paid for, and couldn't quit. So I fired myself and hired an LLM — 99% pay cut, zero complaints. Pick your hashtags: it does the reading, you take the credit. You're welcome.
 
-**Live:** <https://news.graymatter.ch> · GitHub sign-in · pick your hashtags · done.
+**Live:** <https://news.graymatter.ch> · GitHub or Google sign-in · pick your hashtags · done.
 
 <p align="center">
   <img alt="Mobile dashboard"  src="docs/screenshots/dashboard-mobile.jpg"  height="260">
@@ -13,6 +13,7 @@ Keeping up with tech news was a part-time job I didn't sign up for, didn't get p
 ## What's in it
 
 - **20 tags preloaded** (`#ai`, `#cloudflare`, `#postgres`, `#agenticai`…). My opinions, helpfully pre-formed for you. Tap × to drop, `+ add` to add.
+- **60+ curated sources, AI-heavy** — vendor blogs (OpenAI, DeepMind, Anthropic via Google News, Microsoft AI, NVIDIA, Google AI), research outlets (BAIR, MIT News AI, The Gradient), and the usual suspects (HN, Lobsters). Adding a tag the registry doesn't cover triggers an LLM-driven feed-discovery pass.
 - **Composable filters on Search & History** — tag + search + date AND together, all in the URL.
 - **Multi-source dedupe** — HN, vendor blog, and three aggregators "discovered" the same story? One card, `(+3)` chip.
 - **Summaries that earn their word count** — 150–200 words: *what happened → how it works → why you care*.
@@ -48,7 +49,7 @@ Test drive of [Codeflare](https://codeflare.ch) ([repo](https://github.com/nikol
 | DB / Cache / Queues | [D1](https://developers.cloudflare.com/d1/) · [KV](https://developers.cloudflare.com/kv/) · [Queues](https://developers.cloudflare.com/queues/) |
 | LLM | [Workers AI](https://developers.cloudflare.com/workers-ai/): `gpt-oss-120b` primary, `gpt-oss-20b` fallback |
 | Email | [Resend](https://resend.com) |
-| Auth | GitHub OAuth + HMAC-SHA256 JWT |
+| Auth | GitHub OAuth + Google OIDC + HMAC-SHA256 JWT |
 
 ## Deploy your own
 
@@ -119,7 +120,7 @@ npx wrangler d1 migrations apply DB --local
 npm run dev
 ```
 
-Copy `.dev.vars.example` to `.dev.vars`, add GitHub OAuth client ID + secret and a random `OAUTH_JWT_SECRET` (≥32 bytes).
+Copy `.dev.vars.example` to `.dev.vars`, add at least one OAuth client ID + secret pair (GitHub, Google, or both) and a random `OAUTH_JWT_SECRET` (≥32 bytes).
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -52,64 +52,82 @@ Test drive of [Codeflare](https://codeflare.ch) ([repo](https://github.com/nikol
 
 ## Deploy your own
 
-Three steps. The Deploy workflow takes care of D1, KV, queues, migrations, secret push, and (optional) custom-domain bind. No `wrangler deploy` from your laptop.
+Three steps. The Deploy workflow handles D1, KV, queues, migrations, and secret push — no `wrangler deploy` from your laptop.
 
 ### 1. Fork
 
-Click Fork. Pick a name. The default Worker service name is `ai-news-digest`; if you keep that, your URL is `https://ai-news-digest.<your-user>.workers.dev`.
+You know how.
 
 ### 2. Set repo secrets
 
-Settings → Secrets and variables → Actions → New repository secret. Add the four required ones — everything else is optional:
+In your fork: `Settings` > `Secrets and variables` > `Actions` > `New repository secret`. Four required:
+
+- `CLOUDFLARE_API_TOKEN` — see [token scopes](#api-token-scopes) below
+- `CLOUDFLARE_ACCOUNT_ID` — find it on any zone overview in the Cloudflare dashboard
+- `OAUTH_JWT_SECRET` — HMAC key for session cookies. Generate: `openssl rand -base64 32`
+- `APP_URL` — canonical origin (your `*.workers.dev` URL or custom domain)
+
+Plus **at least one OAuth provider pair** (GitHub or Google or both). The landing page renders one button per configured provider, listed alphabetically.
+
+<details>
+<summary><strong>Full secret reference (OAuth providers, optional integrations)</strong></summary>
 
 | Secret | Required | What it's for |
 |---|---|---|
-| `CLOUDFLARE_API_TOKEN` | yes | Token with the scopes listed below. |
-| `CLOUDFLARE_ACCOUNT_ID` | yes | Find it on any zone overview in the Cloudflare dashboard. |
-| `OAUTH_JWT_SECRET` | yes | HMAC key for session cookies. Generate: `openssl rand -base64 32`. Rotating it expires every active session. |
-| `APP_URL` | yes | Canonical origin used by the Origin gate and OAuth callbacks. Use `https://ai-news-digest.<your-user>.workers.dev` if you don't have a custom domain (it works exactly the same — you just give that URL to each provider when registering the OAuth App). |
-| `GH_OAUTH_CLIENT_ID` | one provider pair required | GitHub OAuth App client id. Create at github.com → Settings → Developer settings → OAuth Apps → New. Authorization callback URL is `<APP_URL>/api/auth/github/callback`. Note: the `GH_` prefix (not `GITHUB_`) is mandatory — GitHub Actions reserves the `GITHUB_*` namespace for its built-in tokens. |
+| `GH_OAUTH_CLIENT_ID` | one provider pair required | GitHub OAuth App client id. Create at github.com → Settings → Developer settings → OAuth Apps → New. Authorization callback URL is `<APP_URL>/api/auth/github/callback`. The `GH_` prefix (not `GITHUB_`) is mandatory — GitHub Actions reserves the `GITHUB_*` namespace for its built-in tokens. |
 | `GH_OAUTH_CLIENT_SECRET` | with the id | Generated alongside the GitHub client id. Server-side only. |
 | `GOOGLE_OAUTH_CLIENT_ID` | one provider pair required | Google OAuth 2.0 client id. Create at console.cloud.google.com → APIs & Services → Credentials → OAuth client ID → Web application. Authorized redirect URI is `<APP_URL>/api/auth/google/callback`. |
 | `GOOGLE_OAUTH_CLIENT_SECRET` | with the id | Generated alongside the Google client id. Server-side only. |
-| `RESEND_API_KEY` | optional | [Resend](https://resend.com) key for the daily "your digest is ready" email. When unset, digests still generate and appear in the app — only the email step is skipped. |
-| `RESEND_FROM` | optional | Sender address (e.g. `News Digest <hello@yourdomain.com>`). Required when `RESEND_API_KEY` is set; ignored when not. |
+| `RESEND_API_KEY` | optional | [Resend](https://resend.com) key for the daily "your digest is ready" email. When unset, digests still generate in the app — only the email step is skipped. |
+| `RESEND_FROM` | optional | Sender address (e.g. `News Digest <hello@yourdomain.com>`). Required when `RESEND_API_KEY` is set. |
 | `DEV_BYPASS_TOKEN` | optional | Enables `/api/dev/login` for `scripts/e2e-test.sh`. When unset, the endpoint returns 404. |
 
-**At least one sign-in provider** (the GitHub pair, the Google pair, or both) must be configured — the landing page renders one button per configured provider, listed alphabetically. A pair with only one field set is rejected by the deploy workflow so a half-configured provider never reaches runtime.
+A pair with only one field set is rejected by the deploy workflow so a half-configured provider never reaches runtime.
 
-#### Cloudflare API token scopes
+</details>
+
+<details>
+<summary><strong>API token scopes</strong></summary>
+<a id="api-token-scopes"></a>
 
 Custom token via [dash.cloudflare.com/profile/api-tokens](https://dash.cloudflare.com/profile/api-tokens):
 
 | Scope | Permission | Access | Why |
 |---|---|---|---|
-| Account | Workers Scripts | Edit | Deploys the Worker. |
-| Account | Workers KV Storage | Edit | Auto-creates the KV namespace if it doesn't exist. |
-| Account | D1 | Edit | Auto-creates the D1 database and applies migrations. |
-| Account | Queues | Edit | Auto-creates `scrape-coordinator` and `scrape-chunks`. |
-| Account | Workers AI | Read | LLM inference for summaries + source discovery. |
-| Zone | Zone | Read | Only when binding a custom domain — discovers the zone. |
-| Zone | Workers Routes | Edit | Only when binding a custom domain — attaches the hostname. |
+| Account | Workers Scripts | Edit | Deploys the Worker |
+| Account | Workers KV Storage | Edit | Auto-creates the KV namespace |
+| Account | D1 | Edit | Auto-creates the D1 database and applies migrations |
+| Account | Queues | Edit | Auto-creates `scrape-coordinator` and `scrape-chunks` |
+| Account | Workers AI | Read | LLM inference for summaries + source discovery |
+| Zone | Zone | Read | Only when binding a custom domain — discovers the zone |
+| Zone | Workers Routes | Edit | Only when binding a custom domain — attaches the hostname |
 
 The Zone scopes are skipped automatically when `APP_URL` is a `*.workers.dev` URL.
 
+</details>
+
 ### 3. Deploy
 
-Actions → Deploy → Run workflow → Branch: `main` → **Run workflow**. Takes ~2 minutes. The workflow:
+`Actions` > `Deploy` > `Run workflow` > Branch: `main` > **Run workflow**. Takes ~2 minutes. Future pushes to `main` deploy automatically.
 
-1. Resolves (or creates) the D1 database, KV namespace, and queues in your account via [`scripts/bootstrap-resources.sh`](scripts/bootstrap-resources.sh).
-2. Applies D1 migrations.
-3. Pushes Worker secrets (Resend pair skipped when unset).
-4. `wrangler deploy`.
-5. Binds your `APP_URL` hostname to the Worker (skipped when it's a `*.workers.dev` URL).
-6. Smoke-tests `GET /` returns 200.
+<details>
+<summary><strong>What the workflow does</strong></summary>
 
-Future pushes to `main` deploy automatically.
+1. Resolves (or creates) the D1 database, KV namespace, and queues via [`scripts/bootstrap-resources.sh`](scripts/bootstrap-resources.sh)
+2. Applies D1 migrations
+3. Pushes Worker secrets (Resend pair skipped when unset)
+4. `wrangler deploy`
+5. Binds `APP_URL` to the Worker (skipped on `*.workers.dev`)
+6. Smoke-tests `GET /` returns 200
 
-### 4. Make the admin endpoints non-public
+</details>
 
-Three operator endpoints under `/api/admin/*` (force-refresh + re-discover) need an extra gate so other signed-in users can't trigger them. Cloudflare Access at the zone level — [setup walkthrough](documentation/deployment.md#admin-only-routes-cloudflare-access-gating). Only needed if you bound a custom domain; on `*.workers.dev` your account is already the only signed-in user.
+<details>
+<summary><strong>Custom domain only: gate the admin endpoints</strong></summary>
+
+Three operator endpoints under `/api/admin/*` (force-refresh + re-discover) need an extra gate so other signed-in users can't trigger them. Cloudflare Access at the zone level — [setup walkthrough](documentation/deployment.md#admin-only-routes-cloudflare-access-gating). On `*.workers.dev` your account is already the only signed-in user, so this step is unnecessary.
+
+</details>
 
 ## Local dev
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,6 @@ Keeping up with tech news was a part-time job I didn't sign up for, didn't get p
 ## What's in it
 
 - **20 tags preloaded** (`#ai`, `#cloudflare`, `#postgres`, `#agenticai`…). My opinions, helpfully pre-formed for you. Tap × to drop, `+ add` to add.
-- **60+ curated sources, AI-heavy** — vendor blogs (OpenAI, DeepMind, Anthropic via Google News, Microsoft AI, NVIDIA, Google AI), research outlets (BAIR, MIT News AI, The Gradient), and the usual suspects (HN, Lobsters). Adding a tag the registry doesn't cover triggers an LLM-driven feed-discovery pass.
 - **Composable filters on Search & History** — tag + search + date AND together, all in the URL.
 - **Multi-source dedupe** — HN, vendor blog, and three aggregators "discovered" the same story? One card, `(+3)` chip.
 - **Summaries that earn their word count** — 150–200 words: *what happened → how it works → why you care*.


### PR DESCRIPTION
## Summary

Updates README to reflect features that landed since the last revision:
- Live-link line: "GitHub or Google sign-in"
- New bullet under "What's in it": 60+ curated sources (vendor blogs + research outlets), AI-heavy
- Stack table Auth row: GitHub OAuth + Google OIDC
- Local-dev step: accepts either OAuth pair (or both)

## Test plan

- [ ] CI green
- [ ] Render preview matches intent