### PR TITLE
fix(reading): REQ-READ-007 slow the FLIP cascade (220ms → 450ms)

### DIFF
--- a/src/components/TagStrip.astro
+++ b/src/components/TagStrip.astro
@@ -381,7 +381,7 @@ const selected = initialSelected ?? new Set<string>();
     100% { box-shadow: 0 0 0 0 rgba(0, 0, 0, 0); }
   }
   .tag-chip.tag-chip--just-tapped {
-    animation: tagChipPulse 320ms ease-out;
+    animation: tagChipPulse 500ms ease-out;
   }
   @media (prefers-reduced-motion: reduce) {
     .tag-chip.tag-chip--just-tapped {

--- a/src/lib/tag-railing-flip.ts
+++ b/src/lib/tag-railing-flip.ts
@@ -25,9 +25,15 @@
 //      the helper performs the reorder instantly and skips all
 //      transform animation (AC 7).
 
-const DEFAULT_DURATION_MS = 220;
+// 450ms reads as deliberate motion at the gesture scale users perceive
+// — under 300ms the cascade flashes by so quickly the eye registers
+// only the start and end states and the chip appears to teleport.
+// The pulse hold is sized to outlast the cascade by ~40ms so the
+// just-tapped highlight is visible for the entire move plus a small
+// trailing beat.
+const DEFAULT_DURATION_MS = 450;
 const PULSE_CLASS = 'tag-chip--just-tapped';
-const PULSE_HOLD_MS = 320;
+const PULSE_HOLD_MS = 500;
 const ANIM_LOCK_ATTR = 'data-tag-flip-locked';
 
 export interface FlipChipOptions {


### PR DESCRIPTION
## Summary

Tweak only — bumps the FLIP duration and pulse hold so the cascade reads as motion, not a jump-cut. At 220ms the chip looked like it was teleporting on real hardware.

| Constant | Before | After |
|---|---|---|
| `DEFAULT_DURATION_MS` | 220 | 450 |
| `PULSE_HOLD_MS` | 320 | 500 |
| `tagChipPulse` keyframe | 320ms | 500ms |

No spec change — REQ-READ-007 AC 2 just calls for "smooth motion", which is what 450ms delivers.

## Test plan

- [ ] CI green
- [ ] Tap a chip on /digest desktop — full cascade is visible
- [ ] Tap a chip on /digest mobile — chip slides into slot 0 over ~½ second, doesn't disappear