### PR TITLE
fix(reading): REQ-READ-007 defeat focus auto-scroll + scroll-snap during FLIP

### DIFF
--- a/src/components/TagStrip.astro
+++ b/src/components/TagStrip.astro
@@ -113,6 +113,12 @@ const selected = initialSelected ?? new Set<string>();
     gap: 0.5rem;
     align-items: center;
     padding: 0.25rem 1rem;
+    /* REQ-READ-007 — defeat scroll-anchoring (Chrome implicit
+       behaviour that adjusts scrollLeft when DOM mutates near the
+       scroll position). The FLIP cascade already snapshots and
+       restores scrollLeft around insertBefore, but disabling
+       scroll-anchoring entirely is belt-and-braces. */
+    overflow-anchor: none;
     /* Reserve space on the right for the absolutely-positioned + add
        button (~5rem incl. gap) so the last chip can scroll into view
        without sitting under the button permanently. */

--- a/src/lib/tag-railing-flip.ts
+++ b/src/lib/tag-railing-flip.ts
@@ -144,7 +144,36 @@ export async function flipChipToFront(
       firstRects.set(chip, chip.getBoundingClientRect());
     }
 
+    // CRITICAL — defeat two browser implicit behaviours that would
+    // otherwise shift `strip.scrollLeft` between FIRST and LAST
+    // captures and break the inverse-transform math (especially for
+    // the tapped chip itself):
+    //   (a) :focus auto-scroll: when insertBefore moves a focused
+    //       button to a different DOM position inside a scrollable
+    //       container, Blink/WebKit scroll the container to keep the
+    //       focused element visible. We blur the chip first; later we
+    //       re-focus it with preventScroll: true once the cascade is
+    //       settled (preserves keyboard accessibility).
+    //   (b) scroll-snap re-evaluation: the strip uses
+    //       `scroll-snap-type: x proximity` and chips have
+    //       `scroll-snap-align: start`. DOM mutation re-evaluates
+    //       snap points and may re-snap scrollLeft. We temporarily
+    //       disable scroll-snap for the duration of the FLIP and
+    //       restore it after settle.
+    // Plus a synchronous scrollLeft snapshot/restore around
+    // insertBefore as belt-and-braces in case the browser still
+    // moves scrollLeft despite (a) and (b).
+    const prevSnap = strip.style.scrollSnapType;
+    strip.style.scrollSnapType = 'none';
+    const savedScrollLeft = strip.scrollLeft;
+    const hadFocus = document.activeElement === tappedChip;
+    if (hadFocus) tappedChip.blur();
+
     strip.insertBefore(tappedChip, strip.firstChild);
+
+    if (strip.scrollLeft !== savedScrollLeft) {
+      strip.scrollLeft = savedScrollLeft;
+    }
 
     // INVERT: for each chip whose position changed by more than half
     // a pixel, set transform so it appears to still be in its old
@@ -247,6 +276,13 @@ export async function flipChipToFront(
         }
       }
     }
+
+    // Restore scroll-snap (AFTER the cascade — re-enabling it
+    // mid-transition would re-snap during the slide). Re-focus
+    // the tapped chip with `preventScroll: true` so the keyboard
+    // user doesn't lose their place AND no implicit scroll fires.
+    strip.style.scrollSnapType = prevSnap;
+    if (hadFocus) tappedChip.focus({ preventScroll: true });
   } finally {
     strip.removeAttribute(ANIM_LOCK_ATTR);
   }

--- a/src/lib/tag-railing-flip.ts
+++ b/src/lib/tag-railing-flip.ts
@@ -220,7 +220,14 @@ export async function flipChipToFront(
       tappedChip.classList.remove(POP_CLASS);
 
       // PLAY: next animation frame, transition transforms back to
-      // zero so the cascade plays out.
+      // zero so the cascade plays out. Simultaneously animate
+      // strip.scrollLeft from its current value down to 0 in lockstep
+      // with the cascade — without this the tapped chip slides into
+      // viewport pixel `slot0_offset - scrollLeft` (off-screen-left
+      // when scrollLeft > 0) and the user perceives it as
+      // disappearing. Manual rAF easing matches the cascade's
+      // cubic-bezier(0.2, 0.8, 0.2, 1) timing so chip motion and
+      // scroll motion settle together.
       await new Promise<void>((resolve) => {
         requestAnimationFrame(() => resolve());
       });
@@ -228,6 +235,7 @@ export async function flipChipToFront(
         chip.style.transition = `transform ${durationMs}ms cubic-bezier(0.2, 0.8, 0.2, 1)`;
         chip.style.transform = '';
       }
+      animateScrollTo(strip, 0, durationMs);
 
       // Wait for the longest-moving chip's transitionend (which is
       // the tapped chip — it traverses the most distance) with a
@@ -286,4 +294,31 @@ export async function flipChipToFront(
   } finally {
     strip.removeAttribute(ANIM_LOCK_ATTR);
   }
+}
+
+/** Fire-and-forget rAF easing for `scrollLeft`. We can't use the
+ *  native `scrollTo({behavior: 'smooth'})` because its duration is
+ *  browser-defined (~200-500ms typically) and would fall out of step
+ *  with our 800ms cascade — chip motion and scroll motion would
+ *  desynchronise visibly. Manual easing keeps both curves locked
+ *  together and matches the cascade's cubic-bezier(0.2, 0.8, 0.2, 1)
+ *  via an inline easeOutQuint approximation. */
+function animateScrollTo(
+  strip: HTMLElement,
+  target: number,
+  durationMs: number,
+): void {
+  const start = strip.scrollLeft;
+  if (Math.abs(target - start) < 0.5) return;
+  const t0 = performance.now();
+  const tick = (now: number): void => {
+    const elapsed = now - t0;
+    const t = Math.min(1, elapsed / durationMs);
+    // easeOutQuint — close enough to cubic-bezier(0.2, 0.8, 0.2, 1)
+    // for the eye, no curve-library dependency.
+    const eased = 1 - Math.pow(1 - t, 5);
+    strip.scrollLeft = start + (target - start) * eased;
+    if (t < 1) requestAnimationFrame(tick);
+  };
+  requestAnimationFrame(tick);
 }

--- a/src/lib/tag-railing-flip.ts
+++ b/src/lib/tag-railing-flip.ts
@@ -123,7 +123,10 @@ export async function flipChipToFront(
   // Lock the strip immediately so any re-entrant tap during the
   // pop / hold / cascade is suppressed. The try/finally below
   // guarantees the lock is cleared even if any DOM op throws.
+  // hadFocus is hoisted above the try so the finally block can
+  // restore focus regardless of where in the cascade we throw.
   strip.setAttribute(ANIM_LOCK_ATTR, '1');
+  const hadFocus = document.activeElement === tappedChip;
   try {
     // PHASE 2 — HOLD: deliberate pause so the user's eye lands on
     // the popped chip before anything else moves. The chip is still
@@ -166,7 +169,6 @@ export async function flipChipToFront(
     const prevSnap = strip.style.scrollSnapType;
     strip.style.scrollSnapType = 'none';
     const savedScrollLeft = strip.scrollLeft;
-    const hadFocus = document.activeElement === tappedChip;
     if (hadFocus) tappedChip.blur();
 
     strip.insertBefore(tappedChip, strip.firstChild);
@@ -286,12 +288,14 @@ export async function flipChipToFront(
     }
 
     // Restore scroll-snap (AFTER the cascade — re-enabling it
-    // mid-transition would re-snap during the slide). Re-focus
-    // the tapped chip with `preventScroll: true` so the keyboard
-    // user doesn't lose their place AND no implicit scroll fires.
+    // mid-transition would re-snap during the slide).
     strip.style.scrollSnapType = prevSnap;
-    if (hadFocus) tappedChip.focus({ preventScroll: true });
   } finally {
+    // Keyboard-accessibility safety: restore focus in finally so
+    // even an unexpected throw mid-cascade doesn't leave the user
+    // without a focused chip. preventScroll: true blocks the focus
+    // call's own implicit scroll.
+    if (hadFocus) tappedChip.focus({ preventScroll: true });
     strip.removeAttribute(ANIM_LOCK_ATTR);
   }
 }
@@ -310,15 +314,40 @@ function animateScrollTo(
 ): void {
   const start = strip.scrollLeft;
   if (Math.abs(target - start) < 0.5) return;
+  // User-scroll cancellation: if the user manually scrolls (wheel,
+  // touch, pointer) during our rAF easing, abort immediately so we
+  // don't fight their input. One-shot passive listeners keep the
+  // overhead trivial.
+  let cancelled = false;
+  const cancel = (): void => {
+    cancelled = true;
+  };
+  const opts: AddEventListenerOptions = { once: true, passive: true };
+  strip.addEventListener('wheel', cancel, opts);
+  strip.addEventListener('touchstart', cancel, opts);
+  strip.addEventListener('pointerdown', cancel, opts);
+  const cleanup = (): void => {
+    strip.removeEventListener('wheel', cancel);
+    strip.removeEventListener('touchstart', cancel);
+    strip.removeEventListener('pointerdown', cancel);
+  };
   const t0 = performance.now();
   const tick = (now: number): void => {
+    if (cancelled) {
+      cleanup();
+      return;
+    }
     const elapsed = now - t0;
     const t = Math.min(1, elapsed / durationMs);
     // easeOutQuint — close enough to cubic-bezier(0.2, 0.8, 0.2, 1)
     // for the eye, no curve-library dependency.
     const eased = 1 - Math.pow(1 - t, 5);
     strip.scrollLeft = start + (target - start) * eased;
-    if (t < 1) requestAnimationFrame(tick);
+    if (t < 1) {
+      requestAnimationFrame(tick);
+    } else {
+      cleanup();
+    }
   };
   requestAnimationFrame(tick);
 }


### PR DESCRIPTION
Tapped chip wasn't sliding; railing sometimes reset scrollLeft. Opus subagent confirmed: focus auto-scroll + scroll-snap re-evaluate on insertBefore, shifting scrollLeft between FLIP captures. Fix: blur tapped chip, snapshot+restore scrollLeft, disable scroll-snap during FLIP, add overflow-anchor:none. See commit body for full analysis.