### PR TITLE
fix(admin): force-refresh GET no longer renders raw JSON to browsers

### DIFF
--- a/documentation/api-reference.md
+++ b/documentation/api-reference.md
@@ -315,9 +315,13 @@ Operator-only endpoint that kicks the global-feed coordinator on demand — iden
 
 **Concurrency guard (120-second reuse window):** Before creating a new run, the handler queries for any `scrape_runs` row with `status='running'` started within the last 120 seconds. If one is found it is reused instead of dispatching a second coordinator. This absorbs double-clicks and link-preview bot refetches. Note: two truly concurrent requests can both pass the SELECT before either INSERT commits — the ULIDs are unique so no PK collision collapses the race; for an operator-only endpoint the tradeoff is acceptable.
 
-**POST response:** `303` redirect to `/settings?force_refresh={ok|reused}&run_id={ulid}`.
+**POST response:** `303` redirect to `/settings?force_refresh=ok` (new run) or `/settings?force_refresh=reused` (concurrency guard hit). The `/settings` page reads `?force_refresh=` in `init()` and renders the result in `[data-scrape-progress]`.
 
-**GET response:** `200 { ok: true, scrape_run_id: string, reused: bool }`.
+**GET response (content-negotiated):**
+- Browser or any client without `Accept: application/json` → `303` redirect to `/settings?force_refresh={ok|reused}`.
+- `Accept: application/json` → `200 { ok: true, scrape_run_id: string, reused: bool }`.
+
+Scripts and `curl` callers must send `Accept: application/json` to receive the JSON payload; omitting it triggers a redirect.
 
 **Error response (both methods):** `500 "Failed to dispatch coordinator"` when the D1 INSERT or queue send throws.
 

--- a/sdd/.review-needed.md
+++ b/sdd/.review-needed.md
@@ -2,4 +2,15 @@
 
 Items requiring human attention. Clear entries as they are resolved.
 
-_No current findings._
+## 2026-04-25 — HIGH: Admin force-refresh endpoint has no REQ
+
+**Trigger:** commit `b65339e` changed the GET response shape of `/api/admin/force-refresh` (browsers now get a 303 to `/settings`, scripts opt into JSON via `Accept: application/json`).
+
+**Finding:** No REQ in `sdd/` documents the operator force-refresh contract. The source file `src/pages/api/admin/force-refresh.ts` carries `Implements REQ-OPS-004`, but REQ-OPS-004 is about crawler policy — the annotation is incorrect. The Admin actor is named in `sdd/README.md` as having "force a fresh scrape tick" capability, but no REQ defines the endpoint's behaviour, transports, or auth gate.
+
+**Why escalated (not auto-fixed):** Creating a new REQ across domains is a JUDGMENT call. Conservative unleashed rule: never invent a new REQ when domain placement is ambiguous (observability vs generation).
+
+**Proposed resolution (please pick one):**
+1. Add `REQ-OPS-005: Admin force-refresh endpoint` in `sdd/observability.md` covering both transports (303 default, JSON on Accept), Cloudflare Access gating, and the REUSE_WINDOW_SECONDS guard. Update annotation in `force-refresh.ts` from `REQ-OPS-004` to `REQ-OPS-005`.
+2. Fold the contract into a widened `REQ-GEN-002: Manual refresh` and split user-facing vs operator-triggered paths.
+3. Treat as out-of-scope operator tooling and remove the misleading `REQ-OPS-004` annotation from the source file.

--- a/sdd/changes.md
+++ b/sdd/changes.md
@@ -6,6 +6,8 @@ Each entry is dated, ≤2 sentences, user-facing only. No commit SHAs. No "verif
 
 ## 2026-04-25
 
+- Admin force-refresh GET now content-negotiates: browsers (and the Cloudflare Access post-auth callback that lands users back as a GET) are redirected to `/settings` with an outcome banner, while scripts that send `Accept: application/json` still receive the JSON status body. Operators no longer land on a raw JSON page after clicking Force refresh.
+
 - REQ-SET-001 AC 5 reworded: the native-form save outcome (success "Saved" or named error) now surfaces inline next to the Save button instead of as a top-of-form banner, and the carrying query parameters are stripped after display so a refresh does not re-show stale text. The 303-redirect contract is unchanged.
 
 - REQ-SET-001 AC 5 extended: native form-POST failures now redirect back to the settings page with an inline error banner naming what went wrong, instead of returning a raw JSON error body the browser would render as plain text on a blank page. Unauthenticated native POSTs redirect to the site root since the settings page would itself bounce them away.

--- a/src/pages/api/admin/force-refresh.ts
+++ b/src/pages/api/admin/force-refresh.ts
@@ -112,29 +112,43 @@ export async function POST(context: APIContext): Promise<Response> {
 }
 
 export async function GET(context: APIContext): Promise<Response> {
-  // GET path exists so the operator can trigger from a bookmark or
-  // curl without needing a form. Cloudflare Access is the sole gate
-  // — no Origin check here (there's no state-changing browser flow).
-  // The REUSE_WINDOW_SECONDS guard below prevents accidental storms
-  // from link-preview bots refetching the URL.
+  // GET path exists for two callers:
+  //   1. Browsers landing here via the Cloudflare Access post-auth
+  //      callback — Access intercepts the form's POST, bounces through
+  //      SSO, and returns the user as a GET to the original URL. They
+  //      should never see raw JSON; redirect them back to /settings.
+  //   2. Scripts/curl that explicitly want JSON — they opt in by
+  //      sending `Accept: application/json`.
+  // Cloudflare Access is the sole authn gate (no Origin check needed).
   const env = context.locals.runtime.env;
   if (typeof env.APP_URL !== 'string' || env.APP_URL === '') {
     return new Response('Application not configured', { status: 500 });
   }
+  const appOrigin = originOf(env.APP_URL);
+  const wantsJson = (context.request.headers.get('Accept') ?? '').includes('application/json');
   try {
     const { run_id, reused } = await kickCoordinator(env);
-    return new Response(
-      JSON.stringify({ ok: true, scrape_run_id: run_id, reused }, null, 2),
-      {
-        status: 200,
-        headers: { 'Content-Type': 'application/json; charset=utf-8' },
-      },
-    );
+    if (wantsJson) {
+      return new Response(
+        JSON.stringify({ ok: true, scrape_run_id: run_id, reused }, null, 2),
+        {
+          status: 200,
+          headers: { 'Content-Type': 'application/json; charset=utf-8' },
+        },
+      );
+    }
+    return redirectToSettings(appOrigin, run_id, reused);
   } catch (err) {
     log('error', 'digest.generation', {
       status: 'force_refresh_failed',
       detail: String(err).slice(0, 500),
     });
-    return new Response('Failed to dispatch coordinator', { status: 500 });
+    if (wantsJson) {
+      return new Response('Failed to dispatch coordinator', { status: 500 });
+    }
+    return new Response(null, {
+      status: 303,
+      headers: { Location: `${appOrigin}/settings?force_refresh=error` },
+    });
   }
 }

--- a/src/pages/settings.astro
+++ b/src/pages/settings.astro
@@ -793,9 +793,28 @@ const primaryCta = isFirstRun ? 'Save and continue' : 'Save';
           };
           status.textContent = map[errorCode] ?? 'Could not save your settings.';
         }
-        if (saved !== null || errorCode !== null) {
+        // Force-refresh round-trip — the admin endpoint 303-redirects to
+        // /settings?force_refresh=ok|reused|error after the operator
+        // clicks the button (or after the Cloudflare Access SSO bounce
+        // returns as a GET). Surface the outcome on the Force-refresh
+        // section's status node so the operator gets visible feedback.
+        const forceRefresh = params.get('force_refresh');
+        if (forceRefresh !== null && forceRefresh !== '') {
+          const fr = document.querySelector<HTMLElement>('[data-scrape-progress]');
+          if (fr !== null) {
+            fr.hidden = false;
+            fr.textContent =
+              forceRefresh === 'ok' ? 'Scrape kicked.' :
+              forceRefresh === 'reused' ? 'Scrape already running; reused that run.' :
+              forceRefresh === 'error' ? 'Force refresh failed; check logs.' :
+              `Force refresh: ${forceRefresh}`;
+          }
+        }
+        if (saved !== null || errorCode !== null || forceRefresh !== null) {
           params.delete('saved');
           params.delete('error');
+          params.delete('force_refresh');
+          params.delete('run_id');
           const next = params.toString();
           const newUrl = window.location.pathname + (next === '' ? '' : '?' + next);
           window.history.replaceState({}, '', newUrl);

--- a/tests/pipeline/force-refresh.test.ts
+++ b/tests/pipeline/force-refresh.test.ts
@@ -91,12 +91,16 @@ function makeContext(request: Request, env: Partial<Env>): unknown {
 
 function refreshRequest(
   verb: 'POST' | 'GET',
-  options: { origin?: string | null } = {},
+  options: { origin?: string | null; accept?: string } = {},
 ): Request {
   const headers = new Headers({ 'Content-Type': 'application/json' });
   if (options.origin != null) {
     headers.set('Origin', options.origin);
   }
+  // GET path content-negotiates: Accept: application/json returns JSON;
+  // browsers (no/text-html Accept) get a 303 to /settings. Tests assert
+  // the JSON shape, so they opt in via the header.
+  headers.set('Accept', options.accept ?? 'application/json');
   return new Request(`${APP_URL}/api/admin/force-refresh`, { method: verb, headers });
 }
 


### PR DESCRIPTION
## Summary

User reported that clicking "Force refresh" on /settings sometimes lands on a JSON page (`{ ok: true, scrape_run_id: "...", reused: false }`) instead of returning to /settings.

Cause: Cloudflare Access intercepts the form's POST, bounces through SSO, and the post-auth callback returns the user as a GET to the original URL — which the GET handler then served as raw JSON.

Fix: GET handler now content-negotiates — browsers (no `Accept: application/json`) get a 303 to `/settings?force_refresh=ok|reused`. Scripts/curl opt into JSON via the `Accept` header. Same redirect on error path. /settings init() reads the new query param and renders status text in the existing `[data-scrape-progress]` node ("Scrape kicked." / "Scrape already running; reused that run." / "Force refresh failed; check logs."). URL params stripped via `replaceState`.

## Verification
- code-reviewer: 1 HIGH caught (silent-failure UX) and fixed in `4a8c357`
- spec-reviewer: clean (escalated REQ-ownership question to .review-needed.md)
- doc-updater: 3 HIGH auto-fixed in api-reference.md
- Test fixture updated to send `Accept: application/json` (matches new contract)
- CI green on `1ab194b`

## Test plan
- [ ] CI green on PR
- [ ] Live: click Force refresh → land on /settings with "Scrape kicked." status text. Click again immediately → "Scrape already running; reused that run."