### PR TITLE
Release: PWA install icon + splash title alignment

### DIFF
--- a/public/icons/app-icon.svg
+++ b/public/icons/app-icon.svg
@@ -1,9 +1,12 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
   <!-- App icon / maskable icon for PWA install + splashscreen.
-       MDI `newspaper` (filled) centred inside a square with safe-zone
-       padding so adaptive-icon maskers (Android 8+) don't clip the
-       artwork. The solid background follows prefers-color-scheme so
-       the icon looks native in both light and dark launchers. -->
+       MDI `newspaper` (the canonical segmented-top-edge glyph —
+       https://pictogrammers.com/library/mdi/icon/newspaper/) centred
+       inside a square with safe-zone padding so adaptive-icon maskers
+       (Android 8+) don't clip the artwork. Same glyph as the favicon
+       and the top-left in-app brand so install/splash matches the
+       running app. The solid background follows prefers-color-scheme
+       so the icon looks native in both light and dark launchers. -->
   <style>
     .bg { fill: #0a0a0a; }
     .fg { fill: #fafafa; }
@@ -19,7 +22,7 @@
   <g transform="translate(128 128) scale(10.6667)">
     <path
       class="fg"
-      d="M20,5H4C2.89,5 2,5.89 2,7V17A2,2 0 0,0 4,19H20A2,2 0 0,0 22,17V7A2,2 0 0,0 20,5M20,17H4V7H20V17M6,9H11V11H6V9M6,13H11V15H6V13M18,13H13V15H18V13M18,9H13V11H18V9Z"
+      d="M20,11H4V8H20M20,15H13V13H20M20,19H13V17H20M11,19H4V13H11M20.33,4.67L18.67,3L17,4.67L15.33,3L13.67,4.67L12,3L10.33,4.67L8.67,3L7,4.67L5.33,3L3.67,4.67L2,3V19A2,2 0 0,0 4,21H20A2,2 0 0,0 22,19V3L20.33,4.67Z"
     />
   </g>
 </svg>

--- a/public/manifest.webmanifest
+++ b/public/manifest.webmanifest
@@ -1,7 +1,7 @@
 {
   "id": "/",
   "name": "News Digest",
-  "short_name": "Digest",
+  "short_name": "newsdigest",
   "description": "A daily, AI-curated digest of the news and sources you follow.",
   "start_url": "/digest",
   "scope": "/",

--- a/sdd/changes.md
+++ b/sdd/changes.md
@@ -6,6 +6,8 @@ Each entry is dated, ≤2 sentences, user-facing only. No commit SHAs. No "verif
 
 ## 2026-04-26
 
+- REQ-PWA-001 PWA install/splash artwork now uses the canonical MDI `newspaper` glyph — the same segmented top-edge icon the favicon and top-left in-app brand already use — so the home-screen icon and splash match the running app instead of showing the older filled `newspaper-variant` glyph. The Android home-screen and iOS splash title also shorten from "Digest" to "newsdigest" to mirror the in-app wordmark.
+
 - REQ-READ-007 AC 9 added: tapping a chip already at its destination slot now plays the pop alone — the hold, cascade, and trailing lift are skipped — so the leftmost chip no longer appears to "pulse twice" when re-selected.
 
 - REQ-OPS-004 default Open Graph image switched from SVG to a 1200×630 PNG so Facebook, iMessage, WhatsApp, LinkedIn, and Slack — which silently drop SVG og:images — now render the brand card alongside Twitter and Discord. The SVG remains the master artwork; the PNG is regenerated from it.

--- a/src/components/InstallPrompt.astro
+++ b/src/components/InstallPrompt.astro
@@ -18,7 +18,7 @@
 // phase for independence):
 //   - <meta name="apple-mobile-web-app-capable" content="yes">
 //   - <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
-//   - <meta name="apple-mobile-web-app-title" content="Digest">
+//   - <meta name="apple-mobile-web-app-title" content="newsdigest">
 //   - <link rel="apple-touch-icon" href="/icons/apple-touch-icon.png">
 
 interface Props {

--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -132,7 +132,7 @@ const initialTheme = cookieTheme ?? 'light';
     <meta name="color-scheme" content="light dark" />
     <meta name="apple-mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
-    <meta name="apple-mobile-web-app-title" content="Digest" />
+    <meta name="apple-mobile-web-app-title" content="newsdigest" />
     {/* SVG apple-touch-icon — Safari 13+ supports it; older versions
         fall back to the favicon. We don't ship a raster PNG because we
         have no image pipeline to keep it in sync with the SVG master. */}
@@ -190,7 +190,7 @@ const initialTheme = cookieTheme ?? 'light';
           aria-hidden="true"
           fill="currentColor"
         >
-          {/* MDI newspaper-variant-outline — https://pictogrammers.com/library/mdi/icon/newspaper-variant-outline/ */}
+          {/* MDI newspaper — https://pictogrammers.com/library/mdi/icon/newspaper/ */}
           <path d="M20,11H4V8H20M20,15H13V13H20M20,19H13V17H20M11,19H4V13H11M20.33,4.67L18.67,3L17,4.67L15.33,3L13.67,4.67L12,3L10.33,4.67L8.67,3L7,4.67L5.33,3L3.67,4.67L2,3V19A2,2 0 0,0 4,21H20A2,2 0 0,0 22,19V3L20.33,4.67Z" />
         </svg>
         <span class="site-header__wordmark">
@@ -472,9 +472,10 @@ const initialTheme = cookieTheme ?? 'light';
         text-decoration: none;
       }
 
-      /* Logomark: the MDI newspaper-variant-outline icon. Same glyph
-         used for favicon so the browser tab and the in-app brand stay
-         consistent. Inherits var(--text) via currentColor. */
+      /* Logomark: the MDI `newspaper` icon. Same glyph used for the
+         favicon and the PWA install/splash artwork so the browser tab,
+         home-screen icon, and in-app brand all stay consistent.
+         Inherits var(--text) via currentColor. */
       .site-header__mark {
         display: inline-block;
         color: var(--text);

--- a/tests/pwa/manifest.test.ts
+++ b/tests/pwa/manifest.test.ts
@@ -61,7 +61,7 @@ describe('manifest.webmanifest', () => {
 
   it('REQ-PWA-001: declares required string fields per AC 1', () => {
     expect(manifest.name).toBe('News Digest');
-    expect(manifest.short_name).toBe('Digest');
+    expect(manifest.short_name).toBe('newsdigest');
     expect(typeof manifest.description).toBe('string');
     expect(manifest.description?.length).toBeGreaterThan(0);
     expect(manifest.start_url).toBe('/digest');


### PR DESCRIPTION
## Summary

- Swap the PWA install/splash icon to the canonical MDI [`newspaper`](https://pictogrammers.com/library/mdi/icon/newspaper/) glyph — the same segmented-top-edge icon the favicon and the top-left in-app brand already use. Closes the visual mismatch between the home-screen icon and the running app.
- Shorten `manifest.short_name` and `apple-mobile-web-app-title` from "Digest" to "newsdigest" so the Android home-screen label and the iOS splash title mirror the in-app wordmark.
- Correct a stale MDI glyph name in `Base.astro` comments (cross-checked against Templarian's official SVG repo).

REQ-PWA-001 unchanged (the AC requires the field to exist, not a specific value); manifest test refreshed; `sdd/changes.md` 2026-04-26 entry added.

## Test plan

- [x] CI green on the develop merge (#84)
- [x] All review agents (code-reviewer, spec-reviewer, doc-updater) clean
- [ ] After deploy: install PWA on iOS / Android, confirm new icon shows on the home screen and the splash title reads `newsdigest`