### PR TITLE
PR4: tests + spec/annotation cleanups (CF-014, CF-015, CF-016, CF-054-CF-059, CF-071, CF-074, CF-075)

### DIFF
--- a/src/lib/generate.ts
+++ b/src/lib/generate.ts
@@ -243,11 +243,3 @@ export function extractTokensOut(r: AIRunResponse): number {
   return 0;
 }
 
-/* Expose internals for focused unit tests without forcing them through the
- * full pipeline. Not part of the public contract. */
-export const __test = {
-  parseLLMPayload,
-  sanitizeText,
-  extractTokensIn,
-  extractTokensOut,
-};

--- a/src/lib/title-overlap.ts
+++ b/src/lib/title-overlap.ts
@@ -1,0 +1,53 @@
+// Implements REQ-PIPE-002
+//
+// Token-overlap check used as a defense-in-depth signal during chunk
+// processing. The chunk-consumer pipeline matches LLM-summarised
+// articles back to the input candidate list by echoed index; the
+// overlap check guards against the LLM echoing a correct index but
+// describing a different candidate's story. CF-058 extracted this
+// helper from `scrape-chunk-consumer.ts` so the pure-string logic
+// can be tested in isolation.
+//
+// Conservative by design: when either side has fewer than 2 tokens
+// the signal is too noisy and we accept rather than drop — the cost
+// of a false-reject (lost article) is higher than a false-accept
+// (one mismatched story sneaking through). The chunk consumer carries
+// other guards (canonical-URL match, source name match) that catch
+// the misalignment in the next round of dedup.
+
+const TITLE_STOPWORDS = new Set([
+  'the', 'that', 'this', 'with', 'from', 'into', 'over', 'your', 'their',
+  'have', 'will', 'been', 'were', 'what', 'when', 'about', 'after',
+  'announce', 'announces', 'announced', 'release', 'released', 'launches',
+  'launch', 'update', 'updates', 'updated', 'says', 'said', 'introduces',
+  'introduced', 'adds', 'added', 'gets', 'gains', 'makes', 'made',
+  'using', 'uses', 'based', 'new', 'via', 'now', 'for', 'and',
+]);
+
+/** Extract meaningful tokens from a title for the overlap check:
+ *  lowercase, alnum only, length ≥ 4, not in the small stopword list. */
+export function tokenizeTitle(title: string): Set<string> {
+  const out = new Set<string>();
+  const lowered = title.toLowerCase();
+  const words = lowered.split(/[^a-z0-9]+/);
+  for (const w of words) {
+    if (w.length < 4) continue;
+    if (TITLE_STOPWORDS.has(w)) continue;
+    out.add(w);
+  }
+  return out;
+}
+
+/** True when {@link a} and {@link b} share at least one non-trivial
+ *  token (alnum, length ≥ 4, case-insensitive, stopwords excluded).
+ *  Trivially true when either title produces fewer than 2 meaningful
+ *  tokens — short titles can't generate a reliable overlap signal. */
+export function titlesShareAnyToken(a: string, b: string): boolean {
+  const tokensA = tokenizeTitle(a);
+  const tokensB = tokenizeTitle(b);
+  if (tokensA.size < 2 || tokensB.size < 2) return true;
+  for (const t of tokensA) {
+    if (tokensB.has(t)) return true;
+  }
+  return false;
+}

--- a/src/pages/api/digest/[id].ts
+++ b/src/pages/api/digest/[id].ts
@@ -1,4 +1,4 @@
-// Implements REQ-READ-004, REQ-READ-005
+// Implements REQ-READ-005
 //
 // GET /api/digest/:id — return a specific digest by id, scoped to the
 // authenticated user. The same response shape as /api/digest/today

--- a/src/queue/scrape-chunk-consumer.ts
+++ b/src/queue/scrape-chunk-consumer.ts
@@ -677,10 +677,15 @@ async function loadAllowedTags(kv: KVNamespace): Promise<string[]> {
       }
       cursor = listResult.list_complete ? undefined : listResult.cursor;
     } while (cursor !== undefined);
-  } catch {
+  } catch (err) {
     // KV list is best-effort; fall back to DEFAULT_HASHTAGS if the
     // binding misbehaves. A strict failure would block the chunk for no
-    // strong reason.
+    // strong reason. CF-056: surface the failure in logs so silent
+    // degradation is observable.
+    log('warn', 'digest.generation', {
+      stage: 'allowed_tags.list_failed',
+      error: err instanceof Error ? err.message.slice(0, 200) : String(err).slice(0, 200),
+    });
   }
   return Array.from(set);
 }

--- a/src/queue/scrape-chunk-consumer.ts
+++ b/src/queue/scrape-chunk-consumer.ts
@@ -52,6 +52,7 @@ import { addChunkStats, finishRun } from '~/lib/scrape-run';
 import { generateUlid } from '~/lib/ulid';
 import { applyForeignKeysPragma } from '~/lib/db';
 import { log } from '~/lib/log';
+import { titlesShareAnyToken } from '~/lib/title-overlap';
 
 /** Shape of every `scrape-chunks` queue message. Produced by the
  * coordinator in `src/queue/scrape-coordinator.ts`. `candidates` are the
@@ -653,48 +654,7 @@ export async function processOneChunk(
   void collapsedSet;
 }
 
-/** Very cheap token-overlap check for defense-in-depth against LLM
- * summaries that echo the correct candidate index but describe a
- * different candidate's story. Returns true when the two titles share
- * at least one non-trivial token (alnum, length ≥ 4, case-insensitive,
- * common English stopwords excluded). Returns true trivially when
- * either title is empty or very short (we only reject when BOTH titles
- * are substantial enough to compare meaningfully — never drop on a
- * short headline). */
-function titlesShareAnyToken(a: string, b: string): boolean {
-  const tokensA = tokenizeTitle(a);
-  const tokensB = tokenizeTitle(b);
-  // Be conservative: if either side has fewer than 2 meaningful tokens
-  // the overlap signal is too noisy — accept rather than drop.
-  if (tokensA.size < 2 || tokensB.size < 2) return true;
-  for (const t of tokensA) {
-    if (tokensB.has(t)) return true;
-  }
-  return false;
-}
-
-const TITLE_STOPWORDS = new Set([
-  'the', 'that', 'this', 'with', 'from', 'into', 'over', 'your', 'their',
-  'have', 'will', 'been', 'were', 'what', 'when', 'about', 'after',
-  'announce', 'announces', 'announced', 'release', 'released', 'launches',
-  'launch', 'update', 'updates', 'updated', 'says', 'said', 'introduces',
-  'introduced', 'adds', 'added', 'gets', 'gains', 'makes', 'made',
-  'using', 'uses', 'based', 'new', 'via', 'now', 'for', 'and',
-]);
-
-/** Extract meaningful tokens from a title for the overlap check:
- *  lowercase, alnum only, length ≥ 4, not in the small stopword list. */
-function tokenizeTitle(title: string): Set<string> {
-  const out = new Set<string>();
-  const lowered = title.toLowerCase();
-  const words = lowered.split(/[^a-z0-9]+/);
-  for (const w of words) {
-    if (w.length < 4) continue;
-    if (TITLE_STOPWORDS.has(w)) continue;
-    out.add(w);
-  }
-  return out;
-}
+// titlesShareAnyToken / tokenizeTitle moved to ~/lib/title-overlap (CF-058).
 
 /** Load the tag allowlist: DEFAULT_HASHTAGS ∪ any tag whose
  * `sources:{tag}` KV key exists. De-duplicated, lowercase, no leading `#`. */

--- a/src/queue/scrape-chunk-consumer.ts
+++ b/src/queue/scrape-chunk-consumer.ts
@@ -683,7 +683,7 @@ async function loadAllowedTags(kv: KVNamespace): Promise<string[]> {
     // strong reason. CF-056: surface the failure in logs so silent
     // degradation is observable.
     log('warn', 'digest.generation', {
-      stage: 'allowed_tags.list_failed',
+      status: 'allowed_tags.list_failed',
       error: err instanceof Error ? err.message.slice(0, 200) : String(err).slice(0, 200),
     });
   }

--- a/src/queue/scrape-coordinator.ts
+++ b/src/queue/scrape-coordinator.ts
@@ -445,7 +445,7 @@ interface SourceForFetch {
 /** One evicted feed — emitted by fetchAllSources when a URL's health
  * counter crosses the threshold. Only discovered feeds participate
  * (curated URLs have `discoveredTag = null` and are skipped upstream). */
-interface FeedEviction {
+export interface FeedEviction {
   tag: string;
   url: string;
   failureCount: number;
@@ -664,7 +664,7 @@ async function fetchAllSources(
  *
  * Implements REQ-DISC-003 AC 2-3.
  */
-async function applyEvictions(
+export async function applyEvictions(
   env: Env,
   evictions: FeedEviction[],
   scrape_run_id: string,

--- a/tests/auth/account.test.ts
+++ b/tests/auth/account.test.ts
@@ -255,6 +255,57 @@ describe('DELETE /api/auth/account', () => {
     expect(deleted).toContain('user:12345:banner-dismiss');
   });
 
+  it('REQ-AUTH-005 / CF-054: paginates KV.list via cursor until list_complete is true', async () => {
+    const token = await signSession(
+      { sub: '12345', email: 'a@b.c', ghl: 'a', sv: 1 },
+      JWT_SECRET,
+    );
+    const { db } = makeDb(baseRow());
+    // Multi-page KV.list — first page returns list_complete: false +
+    // a cursor; second page is the terminal page. The handler must
+    // forward the cursor on the second call and delete every key
+    // across both pages.
+    const deleted: string[] = [];
+    const cursorsSeen: Array<string | undefined> = [];
+    const list = vi.fn().mockImplementation(async (args: { prefix?: string; cursor?: string }) => {
+      cursorsSeen.push(args.cursor);
+      if (args.cursor === undefined) {
+        return {
+          keys: [
+            { name: 'user:12345:p1' },
+            { name: 'user:12345:p2' },
+          ],
+          list_complete: false,
+          cursor: 'c2',
+        };
+      }
+      return {
+        keys: [{ name: 'user:12345:p3' }],
+        list_complete: true,
+      };
+    });
+    const kv = {
+      list,
+      delete: vi.fn().mockImplementation(async (name: string) => {
+        deleted.push(name);
+      }),
+    } as unknown as KVNamespace;
+    const req = await deleteRequest({
+      origin: APP_ORIGIN,
+      cookie: `${SESSION_COOKIE_NAME}=${token}`,
+      body: { confirm: 'DELETE' },
+    });
+    await DELETE(makeContext(req, env(db, kv)) as never);
+    // First call has no cursor (initial page); second call carries
+    // 'c2' from the first page's response.
+    expect(cursorsSeen).toEqual([undefined, 'c2']);
+    // All three keys across the two pages got deleted.
+    expect(deleted).toEqual(
+      expect.arrayContaining(['user:12345:p1', 'user:12345:p2', 'user:12345:p3']),
+    );
+    expect(deleted).toHaveLength(3);
+  });
+
   it('REQ-AUTH-005: returns redirect hint in JSON body', async () => {
     const token = await signSession(
       { sub: '12345', email: 'a@b.c', ghl: 'a', sv: 1 },

--- a/tests/email/dispatch-failure.test.ts
+++ b/tests/email/dispatch-failure.test.ts
@@ -471,7 +471,11 @@ describe('dispatchDailyEmails — REQ-MAIL-002 non-blocking failure', () => {
                       tz: 'UTC',
                       digest_hour: 14,
                       digest_minute: 0,
-                      hashtags_json: null,
+                      // Need non-empty tags so selectUnreadHeadlinesForUser
+                      // actually issues the SELECT against D1 — the helper
+                      // short-circuits to [] when userTags is empty,
+                      // skipping the throw path we want to exercise.
+                      hashtags_json: JSON.stringify(['cloudflare']),
                       last_emailed_local_date: null,
                     },
                   ],

--- a/tests/email/dispatch-failure.test.ts
+++ b/tests/email/dispatch-failure.test.ts
@@ -412,4 +412,124 @@ describe('dispatchDailyEmails — REQ-MAIL-002 non-blocking failure', () => {
     expect(stamped2).toHaveLength(1);
     expect(stamped2[0]!.params[1]).toBe('u-retry');
   });
+
+  // ---------- CF-057: APP_URL missing guard ----------------------------
+
+  it('REQ-MAIL-001 / CF-057: missing APP_URL logs once, no DB scan, no fetch', async () => {
+    const calls: SqlCall[] = [];
+    const db = makeDb({
+      distinctTzs: [{ tz: 'UTC' }],
+      usersByTz: { UTC: [] },
+      calls,
+    });
+    const fetchStub = makeFetch({});
+    const spy = logSpyFactory();
+    try {
+      // makeEnv stubs APP_URL — undo it for this single case.
+      const env = makeEnv(db, fetchStub.fetch) as Env;
+      const stripped = { ...env, APP_URL: '' } as unknown as Env;
+      await dispatchDailyEmails(stripped);
+      // No DB read should fire — the guard returns before the tz probe.
+      expect(calls).toHaveLength(0);
+      expect(fetchStub.calls).toHaveLength(0);
+      // Exactly one structured `email.send.failed` line tagged with the
+      // sentinel error reason so an operator can grep it.
+      const failed = spy.logs.filter(
+        (l) => l.event === 'email.send.failed',
+      );
+      expect(failed).toHaveLength(1);
+      expect(
+        (failed[0]!.fields as { error: string }).error,
+      ).toContain('app_url_not_configured');
+    } finally {
+      spy.restore();
+    }
+  });
+
+  // ---------- CF-055: D1 throw on selectUnreadHeadlinesForUser → degraded log ----------
+
+  it('REQ-MAIL-001 / CF-055: D1 failure on the headlines fetch emits email.dispatch.degraded but still sends + stamps', async () => {
+    const calls: SqlCall[] = [];
+    // Special-case the headlines SELECT so it throws while the main
+    // user scan + the tally COUNT keep working.
+    const prepareImpl = vi.fn().mockImplementation((sql: string) => {
+      const bound: unknown[] = [];
+      return {
+        bind: (...params: unknown[]) => {
+          bound.push(...params);
+          return {
+            all: vi.fn().mockImplementation(async () => {
+              calls.push({ sql, params: [...bound], verb: 'all' });
+              if (sql.includes('SELECT id, email, gh_login')) {
+                return {
+                  success: true,
+                  results: [
+                    {
+                      id: 'u-degraded',
+                      email: 'degraded@x.com',
+                      gh_login: 'degraded',
+                      tz: 'UTC',
+                      digest_hour: 14,
+                      digest_minute: 0,
+                      hashtags_json: null,
+                      last_emailed_local_date: null,
+                    },
+                  ],
+                };
+              }
+              if (sql.includes('FROM articles a')) {
+                throw new Error('d1 transient outage on headlines');
+              }
+              return { success: true, results: [] };
+            }),
+            run: vi.fn().mockImplementation(async () => {
+              calls.push({ sql, params: [...bound], verb: 'run' });
+              return { success: true, meta: { changes: 1 } };
+            }),
+            first: vi.fn().mockImplementation(async () => {
+              calls.push({ sql, params: [...bound], verb: 'first' });
+              if (sql.includes('COUNT(DISTINCT a.id)')) return { total: 0 };
+              return null;
+            }),
+          };
+        },
+        all: vi.fn().mockImplementation(async () => {
+          calls.push({ sql, params: [], verb: 'all' });
+          if (sql.includes('SELECT DISTINCT tz')) {
+            return { success: true, results: [{ tz: 'UTC' }] };
+          }
+          return { success: true, results: [] };
+        }),
+      };
+    });
+    const db = { prepare: prepareImpl } as unknown as D1Database;
+    const fetchStub = makeFetch({ 'degraded@x.com': { kind: 'ok' } });
+    const spy = logSpyFactory();
+    try {
+      await dispatchDailyEmails(makeEnv(db, fetchStub.fetch) as Env);
+      // Degraded log fired with the correct user id and reason
+      // substring.
+      const degraded = spy.logs.filter(
+        (l) => l.event === 'email.dispatch.degraded',
+      );
+      expect(degraded.length).toBeGreaterThanOrEqual(1);
+      const headlinesDegraded = degraded.find(
+        (l) =>
+          (l.fields as { user_id: string }).user_id === 'u-degraded' &&
+          String((l.fields as { error: string }).error).includes('headlines_fetch_failed'),
+      );
+      expect(headlinesDegraded).toBeDefined();
+      // Email still sent (the fetch was called for this user).
+      expect(fetchStub.calls.find((c) => c.to === 'degraded@x.com')).toBeDefined();
+      // last_emailed_local_date was stamped on success.
+      const stamped = calls.find(
+        (c) =>
+          c.sql.includes('UPDATE users SET last_emailed_local_date') &&
+          c.verb === 'run',
+      );
+      expect(stamped).toBeDefined();
+    } finally {
+      spy.restore();
+    }
+  });
 });

--- a/tests/generate/sanitize.test.ts
+++ b/tests/generate/sanitize.test.ts
@@ -3,18 +3,16 @@
 //
 // The pipeline guarantees that HTML tags, control characters, and
 // collapsed whitespace never reach the articles table. These tests
-// pin down sanitizeText at the unit level via the `__test` export —
-// full pipeline verification lives in pipeline.test.ts.
+// pin down sanitizeText at the unit level — full pipeline verification
+// lives in pipeline.test.ts.
 //
 // CF-017 deleted sanitizeArticles + GeneratedArticle (production no
-// longer called the helper — the chunk consumer assembles articles
-// inline and only consumes sanitizeText). The dedicated
-// sanitizeArticles describe blocks were removed alongside.
+// longer called the helper). CF-016 deleted the `__test` bag — every
+// helper it exposed (parseLLMPayload, sanitizeText, extractTokensIn,
+// extractTokensOut) was already a direct named export.
 
 import { describe, expect, it } from 'vitest';
-import { __test } from '~/lib/generate';
-
-const { sanitizeText } = __test;
+import { sanitizeText } from '~/lib/generate';
 
 describe('sanitizeText', () => {
   it('REQ-PIPE-002: strips simple HTML tags', () => {

--- a/tests/integration/rediscovery-lifecycle.test.ts
+++ b/tests/integration/rediscovery-lifecycle.test.ts
@@ -214,7 +214,8 @@ describe('rediscovery lifecycle — REQ-DISC-003 / REQ-DISC-006 (CF-075)', () =>
     const after = (await readSourcesEntry()) as {
       feeds: Array<{ url: string }>;
     } | null;
-    expect(after?.feeds.map((f) => f.url)).toEqual([FEED_URL]);
+    expect(after).not.toBeNull();
+    expect(after!.feeds.map((f) => f.url)).toEqual([FEED_URL]);
     expect(await countPendingDiscoveries(SYSTEM_USER_ID, TAG)).toBe(0);
   });
 

--- a/tests/integration/rediscovery-lifecycle.test.ts
+++ b/tests/integration/rediscovery-lifecycle.test.ts
@@ -1,0 +1,259 @@
+// End-to-end integration test for the discovered-feed rediscovery
+// lifecycle — REQ-DISC-003 + REQ-DISC-006 (CF-075).
+//
+// Walks the full chain that turns a flaky discovered feed into a
+// system-owned re-discovery row:
+//
+//   1. `recordFetchResult(env, url, false)` is called repeatedly as the
+//      coordinator's per-source fetch fails. Health counter increments
+//      live in KV (`source_health:{url}`).
+//   2. The 30th consecutive failure (CONSECUTIVE_FETCH_FAILURE_LIMIT)
+//      flips the result to `evicted: true`. The coordinator collects
+//      this in a `FeedEviction[]` payload.
+//   3. `applyEvictions` rewrites `sources:{tag}` in KV (URL removed),
+//      clears the per-URL health counter, and — when the surviving
+//      feed list is empty — INSERTs a `pending_discoveries` row owned
+//      by `__system__` so the next discovery cron tick repopulates the
+//      tag.
+//   4. Curated feeds (those without a `discoveredTag`) never participate
+//      because `applyEvictions` is only called with discovered evictions
+//      upstream — pinned here by asserting that calling applyEvictions
+//      with no evictions is a clean no-op.
+//
+// Uses the @cloudflare/vitest-pool-workers harness so D1 + KV are real
+// miniflare bindings (matching the schema-0005 test pattern).
+
+import { describe, it, expect, beforeAll, beforeEach } from 'vitest';
+import { env, applyD1Migrations } from '../fixtures/cloudflare-test';
+import {
+  CONSECUTIVE_FETCH_FAILURE_LIMIT,
+  recordFetchResult,
+} from '~/lib/feed-health';
+import { applyEvictions } from '~/queue/scrape-coordinator';
+import { SYSTEM_USER_ID } from '~/lib/system-user';
+
+const TAG = 'test-rediscovery';
+const FEED_URL = 'https://flaky-rss.example.com/feed.xml';
+const OTHER_FEED_URL = 'https://stable-rss.example.com/feed.xml';
+const SCRAPE_RUN_ID = '01JREDISCOVERYRUN0000000001';
+
+async function seedSourcesEntry(
+  feeds: Array<{ url: string; name: string }>,
+): Promise<void> {
+  await env.KV.put(
+    `sources:${TAG}`,
+    JSON.stringify({
+      feeds: feeds.map((f) => ({ url: f.url, name: f.name })),
+      discovered_at: Date.now(),
+    }),
+  );
+}
+
+async function readSourcesEntry(): Promise<unknown> {
+  const raw = await env.KV.get(`sources:${TAG}`, 'text');
+  if (raw === null) return null;
+  return JSON.parse(raw);
+}
+
+async function getHealthCount(url: string): Promise<number | null> {
+  const raw = await env.KV.get(`source_health:${url}`, 'text');
+  return raw === null ? null : Number(raw);
+}
+
+async function countPendingDiscoveries(
+  userId: string,
+  tag: string,
+): Promise<number> {
+  const row = await env.DB
+    .prepare(
+      'SELECT COUNT(*) AS c FROM pending_discoveries WHERE user_id = ? AND tag = ?',
+    )
+    .bind(userId, tag)
+    .first<{ c: number }>();
+  return row?.c ?? 0;
+}
+
+describe('rediscovery lifecycle — REQ-DISC-003 / REQ-DISC-006 (CF-075)', () => {
+  beforeAll(async () => {
+    await applyD1Migrations(env.DB, env.DB_MIGRATIONS ?? []);
+    await env.DB.exec('PRAGMA foreign_keys = ON');
+  });
+
+  beforeEach(async () => {
+    // Clear the bits this test mutates. Other test files restore wider
+    // state; we touch only the rediscovery surface.
+    await env.KV.delete(`sources:${TAG}`);
+    await env.KV.delete(`source_health:${FEED_URL}`);
+    await env.KV.delete(`source_health:${OTHER_FEED_URL}`);
+    await env.DB
+      .prepare(
+        'DELETE FROM pending_discoveries WHERE user_id = ? AND tag = ?',
+      )
+      .bind(SYSTEM_USER_ID, TAG)
+      .run();
+  });
+
+  it('REQ-DISC-003 / CF-075: 30th consecutive failure flips evicted=true; earlier failures do not', async () => {
+    // Walk the counter from 1 → 29 — each step is below the threshold.
+    for (let i = 1; i < CONSECUTIVE_FETCH_FAILURE_LIMIT; i += 1) {
+      const result = await recordFetchResult(env, FEED_URL, false);
+      expect(result.evicted).toBe(false);
+      expect(result.count).toBe(i);
+    }
+    // 30th failure → eviction signal. The coordinator collects this in
+    // its FeedEviction[] payload and passes it to applyEvictions.
+    const final = await recordFetchResult(env, FEED_URL, false);
+    expect(final.evicted).toBe(true);
+    expect(final.count).toBe(CONSECUTIVE_FETCH_FAILURE_LIMIT);
+    expect(await getHealthCount(FEED_URL)).toBe(CONSECUTIVE_FETCH_FAILURE_LIMIT);
+  });
+
+  it('REQ-DISC-003 / REQ-DISC-006 / CF-075: full lifecycle — eviction → KV mutation → system requeue', async () => {
+    // Step 1: tag has only the flaky feed in its KV entry. After eviction
+    // the surviving feed list is empty, which triggers the system-owned
+    // re-discovery requeue. Health counter pre-seeded at the threshold so
+    // applyEvictions sees a real eviction signal arriving from upstream.
+    await seedSourcesEntry([{ url: FEED_URL, name: 'Flaky RSS' }]);
+    await env.KV.put(
+      `source_health:${FEED_URL}`,
+      String(CONSECUTIVE_FETCH_FAILURE_LIMIT),
+    );
+
+    // Sanity: nothing in pending_discoveries for the system user yet.
+    expect(await countPendingDiscoveries(SYSTEM_USER_ID, TAG)).toBe(0);
+
+    // Step 2: feed-health crossing the threshold produced this eviction.
+    await applyEvictions(
+      env,
+      [
+        {
+          tag: TAG,
+          url: FEED_URL,
+          failureCount: CONSECUTIVE_FETCH_FAILURE_LIMIT,
+        },
+      ],
+      SCRAPE_RUN_ID,
+    );
+
+    // Step 3a: KV `sources:{tag}` rewritten with surviving feeds (none).
+    const after = (await readSourcesEntry()) as {
+      feeds: Array<{ url: string }>;
+      discovered_at: number;
+    } | null;
+    expect(after).not.toBeNull();
+    expect(after!.feeds).toEqual([]);
+
+    // Step 3b: per-URL health counter cleared so a re-discovered URL at
+    // the same address starts fresh.
+    expect(await getHealthCount(FEED_URL)).toBeNull();
+
+    // Step 3c: system-owned re-discovery row written to D1. This is the
+    // signal the discovery cron uses to repopulate the tag on its next
+    // tick (REQ-DISC-006: `__system__` rows are visible to the cron's
+    // GROUP BY tag query but excluded from per-user-scoped reads).
+    expect(await countPendingDiscoveries(SYSTEM_USER_ID, TAG)).toBe(1);
+    const sysRow = await env.DB
+      .prepare(
+        'SELECT user_id, tag, added_at FROM pending_discoveries WHERE user_id = ? AND tag = ?',
+      )
+      .bind(SYSTEM_USER_ID, TAG)
+      .first<{ user_id: string; tag: string; added_at: number }>();
+    expect(sysRow?.user_id).toBe(SYSTEM_USER_ID);
+    expect(sysRow?.tag).toBe(TAG);
+    expect(typeof sysRow?.added_at).toBe('number');
+  });
+
+  it('REQ-DISC-003 / CF-075: surviving feeds remain → no system requeue, only KV cleanup', async () => {
+    // Tag has TWO discovered feeds; only one is evicted. The surviving
+    // feed list is non-empty, so applyEvictions must NOT enqueue a
+    // re-discovery — the tag still has a live feed.
+    await seedSourcesEntry([
+      { url: FEED_URL, name: 'Flaky RSS' },
+      { url: OTHER_FEED_URL, name: 'Stable RSS' },
+    ]);
+    await env.KV.put(
+      `source_health:${FEED_URL}`,
+      String(CONSECUTIVE_FETCH_FAILURE_LIMIT),
+    );
+
+    await applyEvictions(
+      env,
+      [
+        {
+          tag: TAG,
+          url: FEED_URL,
+          failureCount: CONSECUTIVE_FETCH_FAILURE_LIMIT,
+        },
+      ],
+      SCRAPE_RUN_ID,
+    );
+
+    // Surviving feeds list contains exactly the stable URL.
+    const after = (await readSourcesEntry()) as {
+      feeds: Array<{ url: string; name: string }>;
+    } | null;
+    expect(after).not.toBeNull();
+    expect(after!.feeds.map((f) => f.url)).toEqual([OTHER_FEED_URL]);
+
+    // Evicted URL's health counter cleared; the surviving URL's is
+    // untouched (we never wrote one in this test, so it's null).
+    expect(await getHealthCount(FEED_URL)).toBeNull();
+
+    // No system requeue — the tag still has a live feed.
+    expect(await countPendingDiscoveries(SYSTEM_USER_ID, TAG)).toBe(0);
+  });
+
+  it('REQ-DISC-003 / CF-075: empty evictions list is a no-op', async () => {
+    // Curated-only ticks (no discovered feeds) yield empty eviction
+    // arrays. applyEvictions must handle that path without touching KV
+    // or D1.
+    await seedSourcesEntry([{ url: FEED_URL, name: 'Flaky RSS' }]);
+
+    await applyEvictions(env, [], SCRAPE_RUN_ID);
+
+    const after = (await readSourcesEntry()) as {
+      feeds: Array<{ url: string }>;
+    } | null;
+    expect(after?.feeds.map((f) => f.url)).toEqual([FEED_URL]);
+    expect(await countPendingDiscoveries(SYSTEM_USER_ID, TAG)).toBe(0);
+  });
+
+  it('REQ-DISC-003 / CF-075: idempotent re-trigger — second eviction with same tag-URL pair does not double-insert', async () => {
+    // Defense against at-least-once retry on the coordinator queue:
+    // applyEvictions uses INSERT OR IGNORE on pending_discoveries, so
+    // a second invocation with the same payload must not produce a
+    // duplicate __system__ row.
+    await seedSourcesEntry([{ url: FEED_URL, name: 'Flaky RSS' }]);
+
+    await applyEvictions(
+      env,
+      [
+        {
+          tag: TAG,
+          url: FEED_URL,
+          failureCount: CONSECUTIVE_FETCH_FAILURE_LIMIT,
+        },
+      ],
+      SCRAPE_RUN_ID,
+    );
+    expect(await countPendingDiscoveries(SYSTEM_USER_ID, TAG)).toBe(1);
+
+    // Re-run the eviction (simulates a coordinator queue redelivery).
+    // Re-seed the same KV state because the first call emptied feeds.
+    await seedSourcesEntry([{ url: FEED_URL, name: 'Flaky RSS' }]);
+    await applyEvictions(
+      env,
+      [
+        {
+          tag: TAG,
+          url: FEED_URL,
+          failureCount: CONSECUTIVE_FETCH_FAILURE_LIMIT,
+        },
+      ],
+      SCRAPE_RUN_ID,
+    );
+
+    // Still one row, not two — INSERT OR IGNORE protected the table.
+    expect(await countPendingDiscoveries(SYSTEM_USER_ID, TAG)).toBe(1);
+  });
+});

--- a/tests/lib/generate-parsers.test.ts
+++ b/tests/lib/generate-parsers.test.ts
@@ -1,0 +1,115 @@
+// Tests for the LLM-response parsers in src/lib/generate.ts —
+// REQ-PIPE-002 / REQ-PIPE-008 (CF-016).
+//
+// The chunk consumer and the cross-chunk finalize consumer both feed
+// raw `env.AI.run()` output through these parsers before consuming
+// the structured payload. Both surfaces tolerate the same set of
+// model deviations (already-parsed object, ```json fences, prose
+// preamble, trailing chatter, balanced-brace recovery) so the
+// pipeline can stay idempotent under model upgrades that change how
+// `response_format: json_object` is honoured.
+
+import { describe, it, expect } from 'vitest';
+import { parseLLMPayload, parseLLMJson } from '~/lib/generate';
+
+describe('parseLLMPayload — REQ-PIPE-002', () => {
+  it('REQ-PIPE-002: accepts an already-parsed object on the response field', () => {
+    const out = parseLLMPayload({ articles: [{ title: 'a' }] });
+    expect(out).not.toBeNull();
+    expect(out?.articles).toHaveLength(1);
+  });
+
+  it('REQ-PIPE-002: rejects a non-object response (boolean, number, null)', () => {
+    expect(parseLLMPayload(null)).toBeNull();
+    expect(parseLLMPayload(42)).toBeNull();
+    expect(parseLLMPayload(true)).toBeNull();
+  });
+
+  it('REQ-PIPE-002: rejects an object missing the articles array', () => {
+    expect(parseLLMPayload({ other: 'shape' })).toBeNull();
+    expect(parseLLMPayload({ articles: 'not-array' })).toBeNull();
+  });
+
+  it('REQ-PIPE-002: parses a fenced ```json block with a prose preamble', () => {
+    const raw =
+      'Sure, here is the JSON you asked for:\n\n```json\n' +
+      '{"articles":[{"title":"t","url":"https://e/x"}]}\n```';
+    const out = parseLLMPayload(raw);
+    expect(out?.articles).toHaveLength(1);
+  });
+
+  it('REQ-PIPE-002: parses a bare JSON string', () => {
+    const out = parseLLMPayload('{"articles":[{"title":"t"}]}');
+    expect(out?.articles).toHaveLength(1);
+  });
+
+  it('REQ-PIPE-002: balanced-brace fallback recovers from trailing prose', () => {
+    // The model emits valid JSON then keeps talking. The first-brace
+    // walker should cut at the matching `}` and ignore the suffix.
+    const raw = 'Here you go: {"articles":[{"title":"x"}]} \nLet me know if you want more.';
+    const out = parseLLMPayload(raw);
+    expect(out?.articles).toHaveLength(1);
+  });
+
+  it('REQ-PIPE-002: nested braces inside string literals do not confuse the walker', () => {
+    // The walker must respect "..." string boundaries so a `}` inside
+    // a string literal doesn't close the outer object early.
+    const raw =
+      'preamble {"articles":[{"title":"contains } inside","url":"u"}]} trailing';
+    const out = parseLLMPayload(raw);
+    expect(out?.articles).toHaveLength(1);
+    expect((out?.articles?.[0] as { title: string }).title).toContain('}');
+  });
+
+  it('REQ-PIPE-002: invalid JSON returns null', () => {
+    expect(parseLLMPayload('not json at all')).toBeNull();
+    expect(parseLLMPayload('{ unterminated ')).toBeNull();
+  });
+
+  it('REQ-PIPE-002: empty string returns null', () => {
+    expect(parseLLMPayload('')).toBeNull();
+  });
+});
+
+describe('parseLLMJson — REQ-PIPE-008', () => {
+  it('REQ-PIPE-008: accepts an already-parsed object', () => {
+    const out = parseLLMJson({ dedup_groups: [[1, 2]] });
+    expect(out?.['dedup_groups']).toEqual([[1, 2]]);
+  });
+
+  it('REQ-PIPE-008: parses a fenced ```json finalize response', () => {
+    const raw = '```json\n{"dedup_groups":[[0,3,7]]}\n```';
+    const out = parseLLMJson(raw);
+    expect(out?.['dedup_groups']).toEqual([[0, 3, 7]]);
+  });
+
+  it('REQ-PIPE-008: balanced-brace recovery on prose-wrapped finalize', () => {
+    const raw = 'I found two pairs: {"dedup_groups":[[1,4]]} thank you!';
+    const out = parseLLMJson(raw);
+    expect(out?.['dedup_groups']).toEqual([[1, 4]]);
+  });
+
+  it('REQ-PIPE-008: rejects strings that contain no balanced object', () => {
+    expect(parseLLMJson('plain prose, no json')).toBeNull();
+    expect(parseLLMJson('{ unterminated')).toBeNull();
+  });
+
+  it('REQ-PIPE-008: rejects null / number / boolean', () => {
+    expect(parseLLMJson(null)).toBeNull();
+    expect(parseLLMJson(42)).toBeNull();
+    expect(parseLLMJson(true)).toBeNull();
+  });
+
+  it('REQ-PIPE-008: rejects an empty string', () => {
+    expect(parseLLMJson('')).toBeNull();
+  });
+
+  it('REQ-PIPE-008: returns the parsed object even when it has no dedup_groups (caller validates fields)', () => {
+    // Per the helper's contract, parseLLMJson is the loose parser —
+    // it only enforces "must parse to a non-null object", and leaves
+    // field validation to the caller. The finalize consumer does its
+    // own dedup_groups shape check downstream.
+    const out = parseLLMJson('{"other":"shape"}');
+    expect(out).toEqual({ other: 'shape' });
+  });
+});

--- a/tests/lib/generate-parsers.test.ts
+++ b/tests/lib/generate-parsers.test.ts
@@ -58,7 +58,9 @@ describe('parseLLMPayload — REQ-PIPE-002', () => {
       'preamble {"articles":[{"title":"contains } inside","url":"u"}]} trailing';
     const out = parseLLMPayload(raw);
     expect(out?.articles).toHaveLength(1);
-    expect((out?.articles?.[0] as { title: string }).title).toContain('}');
+    const articles = out?.articles;
+    expect(articles).toBeDefined();
+    expect((articles![0] as { title: string }).title).toContain('}');
   });
 
   it('REQ-PIPE-002: invalid JSON returns null', () => {

--- a/tests/lib/hashtags.test.ts
+++ b/tests/lib/hashtags.test.ts
@@ -1,0 +1,66 @@
+// Tests for src/lib/hashtags.ts — REQ-MAIL-001 / REQ-READ-001 / REQ-SET-002
+// (CF-015). The wrapper delegates to parseJsonStringArray; this file
+// pins the contract end-to-end so a future refactor of the helper or
+// the wrapper can't silently change behaviour.
+//
+// The function is a defensive parser — every branch returns a usable
+// string[] (often `[]`) rather than throwing. The contract is that
+// users.hashtags_json can be NULL, empty, malformed JSON, or an
+// arbitrary JSON value, and the read paths must keep rendering
+// without crashing on a corrupted row.
+
+import { describe, it, expect } from 'vitest';
+import { parseHashtags } from '~/lib/hashtags';
+
+describe('parseHashtags — REQ-MAIL-001 / REQ-READ-001 / REQ-SET-002', () => {
+  it('returns [] for null input', () => {
+    expect(parseHashtags(null)).toEqual([]);
+  });
+
+  it('returns [] for empty string', () => {
+    expect(parseHashtags('')).toEqual([]);
+  });
+
+  it('returns [] for malformed JSON', () => {
+    expect(parseHashtags('{not valid json')).toEqual([]);
+    expect(parseHashtags('["unterminated')).toEqual([]);
+  });
+
+  it('returns [] when the parsed value is not an array', () => {
+    expect(parseHashtags('"a string"')).toEqual([]);
+    expect(parseHashtags('42')).toEqual([]);
+    expect(parseHashtags('null')).toEqual([]);
+    expect(parseHashtags('{"k":"v"}')).toEqual([]);
+  });
+
+  it('filters out non-string entries from a mixed array', () => {
+    expect(parseHashtags('["ai", 42, null, "llm", {"x":1}]')).toEqual([
+      'ai',
+      'llm',
+    ]);
+  });
+
+  it('returns the array untouched on the happy path', () => {
+    expect(parseHashtags('["ai", "llm", "cloudflare"]')).toEqual([
+      'ai',
+      'llm',
+      'cloudflare',
+    ]);
+  });
+
+  it('preserves casing and #-prefix verbatim — no normalisation', () => {
+    // The wrapper is a pass-through. Normalisation (lowercase, #-strip,
+    // trim) is the caller's responsibility — admin retry handlers
+    // layer it on, settings.astro layers it on, the bare email/dashboard
+    // surfaces consume the stored value as-is.
+    expect(parseHashtags('["#AI", "LLM", "  spaced  "]')).toEqual([
+      '#AI',
+      'LLM',
+      '  spaced  ',
+    ]);
+  });
+
+  it('returns [] for an empty JSON array', () => {
+    expect(parseHashtags('[]')).toEqual([]);
+  });
+});

--- a/tests/lib/schema-0005.test.ts
+++ b/tests/lib/schema-0005.test.ts
@@ -1,0 +1,272 @@
+// Integration test for migrations/0005_auth_links.sql — REQ-AUTH-007.
+// CF-014: pin the cross-provider duplicate-email merge logic so a future
+// schema change cannot silently break the collapse contract.
+//
+// The migration runs once at the top of `applyD1Migrations`. Since the
+// test database is empty when the migration fires, the merge is a no-op
+// at that point. To exercise the merge, the test seeds duplicate users
+// + child rows AFTER all migrations are applied, then re-executes
+// steps 2-7 of the 0005 SQL by hand. The DML is identical to what the
+// migration would do at upgrade time on a populated production DB.
+//
+// Two cases:
+//   1. Duplicate email pair, distinct created_at → MIN(created_at) wins,
+//      child rows re-point, auth_links populated for both providers.
+//   2. Duplicate email pair, identical created_at → MIN(id) wins
+//      (tiebreak rule from the GROUP BY ... HAVING u.id = MIN(u.id)).
+
+import { describe, it, expect, beforeAll, beforeEach } from 'vitest';
+import { env, applyD1Migrations } from '../fixtures/cloudflare-test';
+
+function now(): number {
+  return Math.floor(Date.now() / 1000);
+}
+
+interface UserRow {
+  id: string;
+  email: string;
+  gh_login: string;
+  created_at: number;
+}
+
+async function insertUser(db: D1Database, u: UserRow): Promise<void> {
+  await db
+    .prepare(
+      `INSERT INTO users (id, email, gh_login, tz, digest_minute,
+        email_enabled, refresh_window_start, refresh_count_24h,
+        session_version, created_at)
+       VALUES (?, ?, ?, 'UTC', 0, 1, 0, 0, 1, ?)`,
+    )
+    .bind(u.id, u.email, u.gh_login, u.created_at)
+    .run();
+}
+
+async function insertArticle(db: D1Database, id: string, url: string): Promise<void> {
+  const ts = now();
+  await db
+    .prepare(
+      `INSERT INTO articles (id, canonical_url, primary_source_name,
+        primary_source_url, title, details_json, tags_json,
+        published_at, ingested_at, scrape_run_id)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 'run-x')`,
+    )
+    .bind(id, url, 'Source', url, 'Title', '[]', '[]', ts, ts)
+    .run();
+}
+
+/** Steps 2-7 of migrations/0005_auth_links.sql, executed as DML against
+ *  the already-migrated schema. The migration's auth_links table and FK
+ *  cascades are already in place at this point — this re-runs only the
+ *  data-migration portion that depends on the users table being seeded. */
+async function runMergeDml(db: D1Database): Promise<void> {
+  await db.exec(
+    'CREATE TABLE _merge_email_winners (email TEXT NOT NULL PRIMARY KEY, winner_id TEXT NOT NULL)',
+  );
+  await db.exec(
+    "INSERT INTO _merge_email_winners (email, winner_id) " +
+      'SELECT u.email, u.id ' +
+      'FROM users u ' +
+      'JOIN ( ' +
+      '  SELECT email, MIN(created_at) AS winner_created_at ' +
+      '  FROM users ' +
+      "  WHERE id != '__system__' AND email IS NOT NULL AND email != '' " +
+      '  GROUP BY email ' +
+      '  HAVING COUNT(*) > 1 ' +
+      ') g ON g.email = u.email ' +
+      "WHERE u.id != '__system__' AND u.created_at = g.winner_created_at " +
+      'GROUP BY u.email HAVING u.id = MIN(u.id)',
+  );
+
+  await db.exec(
+    'CREATE TABLE _merge_user_merges (loser_id TEXT NOT NULL PRIMARY KEY, winner_id TEXT NOT NULL)',
+  );
+  await db.exec(
+    'INSERT INTO _merge_user_merges (loser_id, winner_id) ' +
+      'SELECT u.id, w.winner_id FROM users u ' +
+      'JOIN _merge_email_winners w ON u.email = w.email ' +
+      "WHERE u.id != '__system__' AND u.id != w.winner_id",
+  );
+
+  await db.exec(
+    'INSERT OR IGNORE INTO article_stars (user_id, article_id, starred_at) ' +
+      'SELECT m.winner_id, s.article_id, s.starred_at FROM article_stars s ' +
+      'JOIN _merge_user_merges m ON s.user_id = m.loser_id',
+  );
+  await db.exec(
+    'INSERT OR IGNORE INTO article_reads (user_id, article_id, read_at) ' +
+      'SELECT m.winner_id, r.article_id, r.read_at FROM article_reads r ' +
+      'JOIN _merge_user_merges m ON r.user_id = m.loser_id',
+  );
+  await db.exec(
+    'INSERT OR IGNORE INTO pending_discoveries (user_id, tag, added_at) ' +
+      'SELECT m.winner_id, p.tag, p.added_at FROM pending_discoveries p ' +
+      'JOIN _merge_user_merges m ON p.user_id = m.loser_id',
+  );
+
+  await db.exec(
+    'INSERT OR IGNORE INTO auth_links (provider, provider_sub, user_id, linked_at) ' +
+      'SELECT ' +
+      "CASE WHEN u.id LIKE '%:%' THEN substr(u.id, 1, instr(u.id, ':') - 1) ELSE 'github' END, " +
+      "CASE WHEN u.id LIKE '%:%' THEN substr(u.id, instr(u.id, ':') + 1) ELSE u.id END, " +
+      'm.winner_id, ' +
+      "COALESCE(u.created_at, CAST(strftime('%s', 'now') AS INTEGER)) " +
+      'FROM users u JOIN _merge_user_merges m ON u.id = m.loser_id',
+  );
+
+  await db.exec('DELETE FROM users WHERE id IN (SELECT loser_id FROM _merge_user_merges)');
+
+  // Step 7: backfill auth_links for every surviving user (winners and
+  // anyone untouched by the merge). Each users row contributes exactly
+  // one alias derived from its current id.
+  await db.exec(
+    'INSERT OR IGNORE INTO auth_links (provider, provider_sub, user_id, linked_at) ' +
+      'SELECT ' +
+      "CASE WHEN id LIKE '%:%' THEN substr(id, 1, instr(id, ':') - 1) ELSE 'github' END, " +
+      "CASE WHEN id LIKE '%:%' THEN substr(id, instr(id, ':') + 1) ELSE id END, " +
+      'id, ' +
+      "COALESCE(created_at, CAST(strftime('%s', 'now') AS INTEGER)) " +
+      "FROM users WHERE id != '__system__'",
+  );
+
+  await db.exec('DROP TABLE _merge_user_merges');
+  await db.exec('DROP TABLE _merge_email_winners');
+}
+
+describe('schema 0005 — REQ-AUTH-007 — duplicate-email collapse', () => {
+  beforeAll(async () => {
+    await applyD1Migrations(env.DB, env.DB_MIGRATIONS ?? []);
+    await env.DB.exec('PRAGMA foreign_keys = ON');
+  });
+
+  beforeEach(async () => {
+    // Scrub everything that might carry user_id refs; auth_links has
+    // ON DELETE CASCADE so it follows users.
+    await env.DB.exec('DELETE FROM article_stars');
+    await env.DB.exec('DELETE FROM article_reads');
+    await env.DB.exec('DELETE FROM pending_discoveries');
+    await env.DB.exec('DELETE FROM auth_links');
+    await env.DB.exec('DELETE FROM article_tags');
+    await env.DB.exec('DELETE FROM article_sources');
+    await env.DB.exec('DELETE FROM articles');
+    await env.DB.exec("DELETE FROM users WHERE id != '__system__'");
+  });
+
+  it('REQ-AUTH-007 / CF-014: collapses duplicate-email pair and re-points child rows', async () => {
+    // Two users sharing the same verified email, signed in via different
+    // providers. The github user came first (lower created_at) → wins.
+    const winnerId = '12345';
+    const loserId = 'google:99999';
+    await insertUser(env.DB, {
+      id: winnerId,
+      email: 'dup@example.com',
+      gh_login: 'duplicate-user',
+      created_at: 1_000,
+    });
+    await insertUser(env.DB, {
+      id: loserId,
+      email: 'dup@example.com',
+      gh_login: 'duplicate-user',
+      created_at: 2_000,
+    });
+
+    await insertArticle(env.DB, '01JAAAA0000000000000000A01', 'https://example.com/a1');
+    await insertArticle(env.DB, '01JAAAA0000000000000000A02', 'https://example.com/a2');
+
+    // Loser stars two articles, one of which the winner already starred.
+    // INSERT OR IGNORE on the merge collapses the overlap.
+    await env.DB
+      .prepare('INSERT INTO article_stars (user_id, article_id, starred_at) VALUES (?, ?, ?)')
+      .bind(winnerId, '01JAAAA0000000000000000A01', now())
+      .run();
+    await env.DB
+      .prepare('INSERT INTO article_stars (user_id, article_id, starred_at) VALUES (?, ?, ?)')
+      .bind(loserId, '01JAAAA0000000000000000A01', now())
+      .run();
+    await env.DB
+      .prepare('INSERT INTO article_stars (user_id, article_id, starred_at) VALUES (?, ?, ?)')
+      .bind(loserId, '01JAAAA0000000000000000A02', now())
+      .run();
+
+    // Loser has a pending discovery the winner doesn't.
+    await env.DB
+      .prepare('INSERT INTO pending_discoveries (user_id, tag, added_at) VALUES (?, ?, ?)')
+      .bind(loserId, 'rust', now())
+      .run();
+
+    await runMergeDml(env.DB);
+
+    // Loser is gone, winner survives.
+    const survivors = await env.DB
+      .prepare("SELECT id FROM users WHERE email = ? AND id != '__system__' ORDER BY id")
+      .bind('dup@example.com')
+      .all<{ id: string }>();
+    expect(survivors.results.map((r) => r.id)).toEqual([winnerId]);
+
+    // Loser's stars re-pointed to winner. Two distinct article_ids in
+    // total (the duplicate row collapsed via INSERT OR IGNORE).
+    const winnerStars = await env.DB
+      .prepare('SELECT article_id FROM article_stars WHERE user_id = ? ORDER BY article_id')
+      .bind(winnerId)
+      .all<{ article_id: string }>();
+    expect(winnerStars.results.map((r) => r.article_id)).toEqual([
+      '01JAAAA0000000000000000A01',
+      '01JAAAA0000000000000000A02',
+    ]);
+
+    // Loser's pending_discoveries also re-pointed.
+    const winnerPending = await env.DB
+      .prepare('SELECT tag FROM pending_discoveries WHERE user_id = ?')
+      .bind(winnerId)
+      .all<{ tag: string }>();
+    expect(winnerPending.results.map((r) => r.tag)).toEqual(['rust']);
+
+    // auth_links populated for both providers, both pointing at winner.
+    const links = await env.DB
+      .prepare('SELECT provider, provider_sub, user_id FROM auth_links WHERE user_id = ? ORDER BY provider')
+      .bind(winnerId)
+      .all<{ provider: string; provider_sub: string; user_id: string }>();
+    expect(links.results).toEqual([
+      { provider: 'github', provider_sub: '12345', user_id: '12345' },
+      { provider: 'google', provider_sub: '99999', user_id: '12345' },
+    ]);
+  });
+
+  it('REQ-AUTH-007 / CF-014: tiebreaks identical created_at via MIN(id)', async () => {
+    // Both users created at the same instant. The `HAVING u.id = MIN(u.id)`
+    // clause in the migration breaks the tie by lexicographic id order.
+    // Numeric '12345' < 'google:99999' under SQLite's TEXT comparison,
+    // so the github row wins.
+    const sharedTs = 5_000;
+    const winnerId = '12345';
+    const loserId = 'google:99999';
+
+    await insertUser(env.DB, {
+      id: winnerId,
+      email: 'tie@example.com',
+      gh_login: 'tie-user',
+      created_at: sharedTs,
+    });
+    await insertUser(env.DB, {
+      id: loserId,
+      email: 'tie@example.com',
+      gh_login: 'tie-user',
+      created_at: sharedTs,
+    });
+
+    await runMergeDml(env.DB);
+
+    const survivors = await env.DB
+      .prepare("SELECT id FROM users WHERE email = ? AND id != '__system__'")
+      .bind('tie@example.com')
+      .all<{ id: string }>();
+    expect(survivors.results.map((r) => r.id)).toEqual([winnerId]);
+
+    // auth_links carries both providers, both → winner.
+    const links = await env.DB
+      .prepare('SELECT provider, user_id FROM auth_links WHERE user_id = ? ORDER BY provider')
+      .bind(winnerId)
+      .all<{ provider: string; user_id: string }>();
+    expect(links.results.map((r) => r.provider)).toEqual(['github', 'google']);
+    expect(links.results.every((r) => r.user_id === winnerId)).toBe(true);
+  });
+});

--- a/tests/lib/title-overlap.test.ts
+++ b/tests/lib/title-overlap.test.ts
@@ -123,11 +123,13 @@ describe('titlesShareAnyToken — REQ-PIPE-002', () => {
         'BetaCorp launch announcement details',
       ),
     ).toBe(true); // 'announcement' + 'details' overlap
+    // Each side must have at least 2 substantive (non-stopword,
+    // length ≥ 4) tokens, otherwise the size<2 short-circuit fires.
     expect(
       titlesShareAnyToken(
-        'AlphaCorp announces release',
-        'BetaCorp announces launch',
+        'AlphaCorp ProductX announces release',
+        'BetaCorp ServiceY announces launch',
       ),
-    ).toBe(false); // 'alphacorp' vs 'betacorp' alone — no overlap; 'announces' is a stopword
+    ).toBe(false); // alphacorp/productx vs betacorp/servicey — no overlap; 'announces' is a stopword
   });
 });

--- a/tests/lib/title-overlap.test.ts
+++ b/tests/lib/title-overlap.test.ts
@@ -1,0 +1,133 @@
+// Tests for src/lib/title-overlap.ts — REQ-PIPE-002 defense-in-depth
+// guard against LLM summaries that echo the correct candidate index
+// but describe a different candidate's story. CF-058 extracted the
+// helper from scrape-chunk-consumer.ts so the contract can be tested
+// in isolation without spinning up the full pipeline fixture.
+
+import { describe, it, expect } from 'vitest';
+import { titlesShareAnyToken, tokenizeTitle } from '~/lib/title-overlap';
+
+describe('tokenizeTitle — REQ-PIPE-002', () => {
+  it('REQ-PIPE-002: lowercases, alnum-splits, drops short tokens', () => {
+    const tokens = tokenizeTitle('Apple ships M5 MacBook Pro');
+    // 'Apple' (5) ✓, 'ships' (5) — wait, 'ships' is NOT a stopword;
+    // 'M5' is 2 chars (skipped), 'MacBook' (7) ✓, 'Pro' (3) skipped.
+    expect(tokens.has('apple')).toBe(true);
+    expect(tokens.has('ships')).toBe(true);
+    expect(tokens.has('macbook')).toBe(true);
+    expect(tokens.has('pro')).toBe(false); // length < 4
+    expect(tokens.has('m5')).toBe(false); // length < 4
+  });
+
+  it('REQ-PIPE-002: strips stopwords from the tokenised set', () => {
+    const tokens = tokenizeTitle('The new launch announced for AI users');
+    // 'the', 'new', 'launch', 'announced', 'for' all stopwords;
+    // only 'users' (5) survives.
+    expect(tokens.has('the')).toBe(false);
+    expect(tokens.has('new')).toBe(false);
+    expect(tokens.has('launch')).toBe(false);
+    expect(tokens.has('announced')).toBe(false);
+    expect(tokens.has('users')).toBe(true);
+  });
+
+  it('REQ-PIPE-002: ignores punctuation when splitting', () => {
+    const tokens = tokenizeTitle('OpenAI/Microsoft: revenue split announced');
+    expect(tokens.has('openai')).toBe(true);
+    expect(tokens.has('microsoft')).toBe(true);
+    expect(tokens.has('revenue')).toBe(true);
+    expect(tokens.has('split')).toBe(true);
+    expect(tokens.has('announced')).toBe(false); // stopword
+  });
+
+  it('REQ-PIPE-002: empty title yields empty token set', () => {
+    expect(tokenizeTitle('').size).toBe(0);
+  });
+
+  it('REQ-PIPE-002: all-stopword title yields empty token set', () => {
+    expect(tokenizeTitle('the new and now').size).toBe(0);
+  });
+});
+
+describe('titlesShareAnyToken — REQ-PIPE-002', () => {
+  it('REQ-PIPE-002: matching titles share tokens', () => {
+    expect(
+      titlesShareAnyToken(
+        'Apple ships M5 MacBook',
+        'Apple unveils M5 MacBook Pro',
+      ),
+    ).toBe(true);
+  });
+
+  it('REQ-PIPE-002: completely unrelated titles do NOT share', () => {
+    // "AlphaCorp acquires BetaCorp" vs "stock market closes higher"
+    // share zero non-stopword tokens of length ≥ 4.
+    expect(
+      titlesShareAnyToken(
+        'AlphaCorp acquires BetaCorp',
+        'stock market closes higher',
+      ),
+    ).toBe(false);
+  });
+
+  it('REQ-PIPE-002: short titles are accepted (signal too noisy)', () => {
+    // The helper accepts when EITHER side has fewer than 2 meaningful
+    // tokens. This is by design — short titles can't generate a
+    // reliable mismatch signal so we never drop on them.
+    expect(titlesShareAnyToken('hi', 'totally different content')).toBe(true);
+    expect(titlesShareAnyToken('a b c', 'unrelated lengthy article title')).toBe(true);
+  });
+
+  it('REQ-PIPE-002: punctuation differences do not break match', () => {
+    expect(
+      titlesShareAnyToken(
+        'Microsoft, Apple announce new partnership',
+        'Microsoft & Apple — partnership details',
+      ),
+    ).toBe(true);
+  });
+
+  it('REQ-PIPE-002: case differences do not break match', () => {
+    expect(
+      titlesShareAnyToken(
+        'GOOGLE quantum chip benchmark',
+        'google Quantum Chip Benchmark',
+      ),
+    ).toBe(true);
+  });
+
+  it('REQ-PIPE-002: empty titles are accepted (trivially)', () => {
+    expect(titlesShareAnyToken('', 'whatever lengthy headline goes here')).toBe(true);
+    expect(titlesShareAnyToken('whatever lengthy headline', '')).toBe(true);
+    expect(titlesShareAnyToken('', '')).toBe(true);
+  });
+
+  it('REQ-PIPE-002: single shared substantive token is enough to match', () => {
+    expect(
+      titlesShareAnyToken(
+        'OpenAI tightens API rate limits',
+        'After backlash, OpenAI relaxes new policy',
+      ),
+    ).toBe(true);
+  });
+
+  it('REQ-PIPE-002: shared stopwords do NOT count as overlap', () => {
+    // "the new release" vs "the new launch" — only stopwords overlap.
+    // Tokenisation drops everything → both sides yield 0 tokens
+    // → trivially-true short-circuit fires (size < 2).
+    // The intent of the test is to pin that stopwords alone don't
+    // cause a false positive when there ARE non-stopword tokens on
+    // each side.
+    expect(
+      titlesShareAnyToken(
+        'AlphaCorp release announcement details',
+        'BetaCorp launch announcement details',
+      ),
+    ).toBe(true); // 'announcement' + 'details' overlap
+    expect(
+      titlesShareAnyToken(
+        'AlphaCorp announces release',
+        'BetaCorp announces launch',
+      ),
+    ).toBe(false); // 'alphacorp' vs 'betacorp' alone — no overlap; 'announces' is a stopword
+  });
+});

--- a/tests/pipeline/chunk-consumer.test.ts
+++ b/tests/pipeline/chunk-consumer.test.ts
@@ -839,4 +839,56 @@ describe('scrape-chunk-consumer — REQ-PIPE-002', () => {
     expect(articleInserts[0]!.params).toContain('A');
     expect(articleInserts[0]!.params).not.toContain('Hallucinated');
   });
+
+  it('REQ-PIPE-002 / CF-056: KV.list failure on loadAllowedTags emits degraded log and falls back to DEFAULT_HASHTAGS', async () => {
+    // The chunk consumer reads the tag allowlist from KV (`sources:*`)
+    // unioned with DEFAULT_HASHTAGS. If KV.list throws (binding outage,
+    // transient 500), the consumer must NOT block the chunk — it falls
+    // back to the bundled defaults and emits a structured warn log so
+    // operators can spot the silent degradation.
+    const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    try {
+      const aiResponse = {
+        response: JSON.stringify({
+          // Tag is in DEFAULT_HASHTAGS — survives even with empty KV result.
+          articles: [{ title: 'A', details: 'body.', tags: ['cloudflare'] }],
+          dedup_groups: [],
+        }),
+        usage: { input_tokens: 10, output_tokens: 10 },
+      };
+      const { db, records } = makeDb();
+      const { kv } = makeKv();
+      // Override list to throw — simulates a KV outage during the
+      // allowed-tags scan. The consumer's catch block should swallow it.
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (kv.list as any) = vi.fn().mockRejectedValue(new Error('kv list 500'));
+      const env = makeEnv(db, kv, aiResponse);
+
+      await expect(processOneChunk(env, makeChunk())).resolves.toBeUndefined();
+
+      // Degraded log fired with the structured event field.
+      const degradedLog = consoleSpy.mock.calls.find((args: unknown[]) => {
+        const payload = args[0];
+        return (
+          typeof payload === 'string' &&
+          payload.includes('allowed_tags.list_failed')
+        );
+      });
+      expect(degradedLog).toBeDefined();
+      const payload = degradedLog![0] as string;
+      expect(payload).toContain('"level":"warn"');
+      expect(payload).toContain('kv list 500');
+
+      // The chunk still wrote the article — DEFAULT_HASHTAGS fallback
+      // accepted `cloudflare` so the row landed in articles.
+      const articleInserts = records.filter(
+        (r) =>
+          r.via === 'batch' &&
+          r.sql.startsWith('INSERT OR IGNORE INTO articles'),
+      );
+      expect(articleInserts.length).toBe(1);
+    } finally {
+      consoleSpy.mockRestore();
+    }
+  });
 });

--- a/tests/pipeline/cleanup.test.ts
+++ b/tests/pipeline/cleanup.test.ts
@@ -544,4 +544,20 @@ describe('cleanup cron — REQ-DISC-006 stuck-tag prune', () => {
     // After prune+sweep, the cache is gone.
     expect(await env.KV.get('sources:eldenring')).toBeNull();
   });
+
+  it('REQ-DISC-006 / CF-074: legacy #-prefixed and mixed-case entries match the lower-cased tag and get pruned', async () => {
+    // Legacy hashtags_json rows can carry entries with a leading `#`
+    // and mixed casing (the write-path normalisation landed later).
+    // The prune must strip the prefix and lowercase the entry before
+    // comparing against the stuck-tag set, otherwise a stuck KV
+    // entry `sources:eldenring` would never match a stored
+    // `["#EldenRing"]` even though they describe the same tag.
+    await setUserHashtags(env.DB, USER_ID, ['ai', '#EldenRing']);
+    await seedEmptySources('eldenring', Date.now() - 8 * 86400 * 1000);
+
+    const result = await runCleanup(env);
+
+    expect(result.stuckTagsPruned).toBe(1);
+    expect(await getUserHashtags(USER_ID)).toEqual(['ai']);
+  });
 });

--- a/tests/sources/published-at.test.ts
+++ b/tests/sources/published-at.test.ts
@@ -166,22 +166,23 @@ describe('Atom feed extraction — <published> / <updated>', () => {
   const extract = extractorFor('googlenews');
 
   it('parses Atom <published> into published_at', () => {
+    // CF-071: the parser is configured with `attributeNamePrefix: ''`
+    // (see src/lib/sources.ts), so fxp emits attributes without a
+    // prefix — the link object's attribute is `href`, not `@_href`.
+    // The previous fixture used `@_href` and a silent early-return
+    // that masked the failure.
     const parsed = {
       feed: {
         entry: {
           title: 'Atom post',
-          link: { '@_href': 'https://example.com/atom' },
+          link: { href: 'https://example.com/atom' },
           published: '2026-04-02T10:00:00Z',
         },
       },
     };
     const [head] = extract(parsed);
-    // atomLinkHref needs the real attr key. fxp emits either a string
-    // or an object with `@_href` depending on parser flags. If the
-    // extractor couldn't resolve the link the item is dropped, and
-    // this test exits without asserting the date. Guard via ?.
-    if (head === undefined) return;
-    expect(head.published_at).toBe(
+    expect(head).toBeDefined();
+    expect(head?.published_at).toBe(
       Math.floor(Date.parse('2026-04-02T10:00:00Z') / 1000),
     );
   });


### PR DESCRIPTION
## Summary

PR4 of the 5-PR remediation plan for the 2026-04-27 ultrareview (75 findings). Pure additive: net new tests for previously unspec'd silent-degradation paths, plus two annotation cleanups. The only production-source touches are: deletion of the `__test` export bag (helpers were already direct named exports), one new `digest.generation` warn log inside an existing catch block, and one annotation removal for a deprecated REQ.

## Findings addressed

### New tests

- **CF-014** — `tests/lib/schema-0005.test.ts`. Pins migration 0005's duplicate-email collapse: `MIN(created_at)` winner, `MIN(id)` tiebreak, child rows re-pointed (article_stars, pending_discoveries), auth_links populated for both providers via the loser-INSERT + survivor-backfill steps. Re-runs the merge DML against seeded duplicates post-applyMigrations.
- **CF-015** — `tests/lib/hashtags.test.ts`. Six branches for `parseHashtags`: null, empty, malformed JSON, non-array, mixed-array, happy-path. Pins the actual contract — no `#`-stripping, no normalization at this layer.
- **CF-016** — `tests/lib/generate-parsers.test.ts`. 16 cases for `parseLLMPayload` + `parseLLMJson`: already-parsed, fenced JSON, prose preamble, balanced-brace fallback, nested string braces, invalid input. Helpers were already direct named exports — this PR also deletes the `__test` bag.
- **CF-054** — `tests/auth/account.test.ts` extension. Cursor pagination via `KV.list` until `list_complete: true`. Asserts cursor is passed correctly.
- **CF-055** — `tests/email/dispatch-failure.test.ts` extension. D1 throw on `selectUnreadHeadlinesForUser` → `email.dispatch.degraded` log, email still sends, `last_emailed_local_date` stamped.
- **CF-056** — `tests/pipeline/chunk-consumer.test.ts` extension. KV.list failure on `loadAllowedTags` → emit `allowed_tags.list_failed` warn + DEFAULT_HASHTAGS fallback (was a silent swallow).
- **CF-057** — `tests/email/dispatch-failure.test.ts` extension. Missing APP_URL → log once, no DB scan, no fetch.
- **CF-058** — `tests/lib/title-overlap.test.ts` (helper extracted from chunk-consumer). 14 cases pinning stop-words, punctuation, case, empty-titles short-circuit, unrelated-title rejection.
- **CF-071** — `tests/sources/published-at.test.ts:183` fix. fxp parser uses `attributeNamePrefix: ''`, so the Atom link attribute is `href`, not `@_href`. Replaced silent early-return with `expect(head).toBeDefined()`.
- **CF-074** — `tests/pipeline/cleanup.test.ts` extension. Legacy `#`-prefixed and mixed-case stuck-tag entries match the lowercased tag and get pruned by `runStuckTagPrune`.
- **CF-075** — `tests/integration/rediscovery-lifecycle.test.ts`. End-to-end walk of REQ-DISC-003 + REQ-DISC-006: 30 consecutive failures → eviction signal → KV mutation → `__system__` requeue. Five cases: threshold flip, full lifecycle, surviving-feed short-circuit, empty-evictions no-op, idempotent redelivery.

### Spec/annotation cleanups

- **CF-016** — Deleted the `__test` export bag in `src/lib/generate.ts` (every helper it exposed was already a direct named export).
- **CF-058** — Extracted `tokenizeTitle` + `titlesShareAnyToken` from `src/queue/scrape-chunk-consumer.ts` to `src/lib/title-overlap.ts`. Carries `// Implements REQ-PIPE-002`.
- **CF-059** — Removed the deprecated `REQ-READ-004` annotation from `src/pages/api/digest/[id].ts` (REQ marked `Deprecated` with `Replaced By: REQ-PIPE-001` and `Removed In: 2026-04-23`).

### Production-side bridges

- `src/queue/scrape-chunk-consumer.ts`: new `log('warn', 'digest.generation', { status: 'allowed_tags.list_failed', error })` inside the existing catch block in `loadAllowedTags`. Fallback to DEFAULT_HASHTAGS unchanged. Pure observability addition.
- `src/queue/scrape-coordinator.ts`: `applyEvictions` and `FeedEviction` exported so the new integration test can drive the eviction step directly. Visibility-only change.

## Test plan

- [ ] CI green on review-2026-04-27/tests-and-annotations PR
- [ ] No deprecated REQ-READ-004 references remain anywhere outside sdd/ and changes.md
- [ ] No `__test` bag references remain in src/
- [ ] All new test files use the proper REQ tags in `it()` names so spec-reviewer's grep finds them