### PR TITLE
fix(security): close CodeQL #170, #142, #166, #20, #171 + SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,52 @@
+# Security Policy
+
+## Supported Versions
+
+Only the deployed `main` branch is supported. The repo's `develop`
+branch is the staging line for the next deploy and may carry unfixed
+issues. There are no semver releases — production is whatever
+`main` currently points to.
+
+## Reporting a Vulnerability
+
+If you find something that looks security-relevant — a way to read
+another user's data, bypass auth, escape rate limits, or have the LLM
+backend produce output that didn't come from one of the user's
+sources — please **do not** open a public GitHub issue.
+
+Instead, email the owner directly via
+[GitHub's private vulnerability reporting](https://github.com/nikolanovoselec/ai-news-digest/security/advisories/new).
+That keeps the issue confidential while we investigate. A first
+response should land within a few days; for anything user-data-related
+the fix is treated as P0 and shipped as soon as a deploy can be cut.
+
+If the GitHub form is not available, the project owner's contact is
+listed on [graymatter.ch](https://graymatter.ch).
+
+## What's in scope
+
+- Authentication and session cookies
+  ([REQ-AUTH-001](sdd/authentication.md#req-auth-001-sign-in-with-a-federated-identity-provider),
+  [REQ-AUTH-002](sdd/authentication.md#req-auth-002-session-cookie-and-instant-revocation),
+  [REQ-AUTH-007](sdd/authentication.md#req-auth-007-cross-provider-account-dedup))
+- Origin / CSRF defense on state-changing endpoints
+  ([REQ-AUTH-003](sdd/authentication.md#req-auth-003-csrf-defense-for-state-changing-endpoints))
+- Admin endpoints (Cloudflare Access + session + ADMIN_EMAIL match,
+  [REQ-AUTH-001 AC 8](sdd/authentication.md#req-auth-001-sign-in-with-a-federated-identity-provider))
+- Rate-limit bypass paths
+  ([REQ-AUTH-001 AC 9](sdd/authentication.md#req-auth-001-sign-in-with-a-federated-identity-provider))
+- LLM prompt injection that produces fabricated source attributions
+  ([REQ-PIPE-002](sdd/generation.md#req-pipe-002-chunked-summarisation-and-tagging))
+- Anything that bypasses the per-user data scope
+
+## What's out of scope
+
+- Reports based purely on automated scanner output (Scorecard, npm
+  audit) without a concrete exploit. The `documentation/decisions/`
+  ADRs and `sdd/.review-needed.md` track the project's stance on those.
+- DoS via legitimate traffic shapes. Cloudflare's edge handles those.
+- Third-party scanners flagging "GitHub-owned action not pinned by
+  hash" — see ADR / scorecard policy in repo for rationale.
+- Issues that require an authenticated session AND a separate
+  privilege escalation we already document as the operator's
+  responsibility (e.g. an attacker with the operator's GitHub creds).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -27,7 +27,7 @@ listed on [graymatter.ch](https://graymatter.ch).
 
 - Authentication and session cookies
   ([REQ-AUTH-001](sdd/authentication.md#req-auth-001-sign-in-with-a-federated-identity-provider),
-  [REQ-AUTH-002](sdd/authentication.md#req-auth-002-session-cookie-and-instant-revocation),
+  [REQ-AUTH-002](sdd/authentication.md#req-auth-002-access-token--refresh-token-instant-revocation),
   [REQ-AUTH-007](sdd/authentication.md#req-auth-007-cross-provider-account-dedup))
 - Origin / CSRF defense on state-changing endpoints
   ([REQ-AUTH-003](sdd/authentication.md#req-auth-003-csrf-defense-for-state-changing-endpoints))
@@ -36,7 +36,7 @@ listed on [graymatter.ch](https://graymatter.ch).
 - Rate-limit bypass paths
   ([REQ-AUTH-001 AC 9](sdd/authentication.md#req-auth-001-sign-in-with-a-federated-identity-provider))
 - LLM prompt injection that produces fabricated source attributions
-  ([REQ-PIPE-002](sdd/generation.md#req-pipe-002-chunked-summarisation-and-tagging))
+  ([REQ-PIPE-002](sdd/generation.md#req-pipe-002-chunked-llm-processing-with-json-output-contract))
 - Anything that bypasses the per-user data scope
 
 ## What's out of scope

--- a/documentation/deployment.md
+++ b/documentation/deployment.md
@@ -155,3 +155,4 @@ Keep the Cloudflare Access policy in sync with deploys — Access is the first l
 
 - [Configuration](configuration.md) — Env vars and secrets
 - [Architecture](architecture.md) — System overview
+- [Security Policy](../SECURITY.md) — Vulnerability reporting scope and contact

--- a/sdd/.review-needed.md
+++ b/sdd/.review-needed.md
@@ -2,6 +2,21 @@
 
 Items requiring human attention. Clear entries as they are resolved.
 
+## 2026-04-27 — Broken anchor links in `SECURITY.md` to spec REQs
+
+**Severity:** MEDIUM (documentation cross-reference resolves to a non-existent heading slug).
+
+**What's wrong:** The new `SECURITY.md` (added in fix/codeql-batch-rebased to close CodeQL #20) names two REQs with titles that do not match the live headings in `sdd/`:
+
+1. Line 30: link text `REQ-AUTH-002` paired with anchor `#req-auth-002-session-cookie-and-instant-revocation`. The actual heading at `sdd/authentication.md:32` is `### REQ-AUTH-002: Access token + refresh token, instant revocation`, which renders as anchor `#req-auth-002-access-token--refresh-token-instant-revocation`. GitHub will silently drop users at the file top.
+2. Line 41: link text `REQ-PIPE-002` paired with anchor `#req-pipe-002-chunked-summarisation-and-tagging`. The actual heading at `sdd/generation.md:31` is `### REQ-PIPE-002: Chunked LLM processing with JSON output contract`, anchor `#req-pipe-002-chunked-llm-processing-with-json-output-contract`. Same silent-drop behaviour.
+
+**Why spec-reviewer didn't auto-fix:** `SECURITY.md` is at the repo root, not inside `sdd/`. Editing it is `doc-updater`'s lane, not spec-reviewer's. The REQ headings themselves are correct and stable; only the doc's cross-references are stale.
+
+**Recommended fix (next doc-updater run):** update both anchors in `SECURITY.md` to match the current REQ headings — either regenerate the anchor slugs from the live headings, or replace the anchored deep-links with plain `sdd/authentication.md` / `sdd/generation.md` references that don't depend on heading slugs (more durable across REQ rewordings). The link text labels (`REQ-AUTH-002`, `REQ-PIPE-002`) are fine and should stay.
+
+**Lane:** `doc-updater`'s lane.
+
 ## 2026-04-27 — REQ-AUTH-008 AC 3 coverage gap
 
 **Severity:** MEDIUM (residual; not auto-fixable by spec-reviewer).

--- a/sdd/.review-needed.md
+++ b/sdd/.review-needed.md
@@ -2,21 +2,6 @@
 
 Items requiring human attention. Clear entries as they are resolved.
 
-## 2026-04-27 — Broken anchor links in `SECURITY.md` to spec REQs
-
-**Severity:** MEDIUM (documentation cross-reference resolves to a non-existent heading slug).
-
-**What's wrong:** The new `SECURITY.md` (added in fix/codeql-batch-rebased to close CodeQL #20) names two REQs with titles that do not match the live headings in `sdd/`:
-
-1. Line 30: link text `REQ-AUTH-002` paired with anchor `#req-auth-002-session-cookie-and-instant-revocation`. The actual heading at `sdd/authentication.md:32` is `### REQ-AUTH-002: Access token + refresh token, instant revocation`, which renders as anchor `#req-auth-002-access-token--refresh-token-instant-revocation`. GitHub will silently drop users at the file top.
-2. Line 41: link text `REQ-PIPE-002` paired with anchor `#req-pipe-002-chunked-summarisation-and-tagging`. The actual heading at `sdd/generation.md:31` is `### REQ-PIPE-002: Chunked LLM processing with JSON output contract`, anchor `#req-pipe-002-chunked-llm-processing-with-json-output-contract`. Same silent-drop behaviour.
-
-**Why spec-reviewer didn't auto-fix:** `SECURITY.md` is at the repo root, not inside `sdd/`. Editing it is `doc-updater`'s lane, not spec-reviewer's. The REQ headings themselves are correct and stable; only the doc's cross-references are stale.
-
-**Recommended fix (next doc-updater run):** update both anchors in `SECURITY.md` to match the current REQ headings — either regenerate the anchor slugs from the live headings, or replace the anchored deep-links with plain `sdd/authentication.md` / `sdd/generation.md` references that don't depend on heading slugs (more durable across REQ rewordings). The link text labels (`REQ-AUTH-002`, `REQ-PIPE-002`) are fine and should stay.
-
-**Lane:** `doc-updater`'s lane.
-
 ## 2026-04-27 — REQ-AUTH-008 AC 3 coverage gap
 
 **Severity:** MEDIUM (residual; not auto-fixable by spec-reviewer).

--- a/src/lib/article-fetch.ts
+++ b/src/lib/article-fetch.ts
@@ -50,16 +50,24 @@ const SNIPPET_CAP = 3000;
 export function extractArticleText(html: string): string {
   // Drop non-content blocks BEFORE tag-stripping so their contents
   // don't leak in.
+  //
+  // Closing-tag pattern accepts optional whitespace + attribute-shaped
+  // garbage between the tag name and `>` (e.g. `</script >`,
+  // `</script\n>`, `</script foo>`). The HTML spec is permissive
+  // enough that real-world parsers tolerate these forms, and the
+  // strict `</script>` literal CodeQL flagged (#142, js/bad-tag-filter)
+  // would let an attacker smuggle a `<script>...</script foo>` block
+  // past the strip and into the LLM-prompt body.
   const cleaned = html
-    .replace(/<script[\s\S]*?<\/script>/gi, ' ')
-    .replace(/<style[\s\S]*?<\/style>/gi, ' ')
-    .replace(/<noscript[\s\S]*?<\/noscript>/gi, ' ')
-    .replace(/<nav[\s\S]*?<\/nav>/gi, ' ')
-    .replace(/<header[\s\S]*?<\/header>/gi, ' ')
-    .replace(/<footer[\s\S]*?<\/footer>/gi, ' ')
-    .replace(/<aside[\s\S]*?<\/aside>/gi, ' ')
-    .replace(/<form[\s\S]*?<\/form>/gi, ' ')
-    .replace(/<svg[\s\S]*?<\/svg>/gi, ' ');
+    .replace(/<script\b[\s\S]*?<\/script\s*>/gi, ' ')
+    .replace(/<style\b[\s\S]*?<\/style\s*>/gi, ' ')
+    .replace(/<noscript\b[\s\S]*?<\/noscript\s*>/gi, ' ')
+    .replace(/<nav\b[\s\S]*?<\/nav\s*>/gi, ' ')
+    .replace(/<header\b[\s\S]*?<\/header\s*>/gi, ' ')
+    .replace(/<footer\b[\s\S]*?<\/footer\s*>/gi, ' ')
+    .replace(/<aside\b[\s\S]*?<\/aside\s*>/gi, ' ')
+    .replace(/<form\b[\s\S]*?<\/form\s*>/gi, ' ')
+    .replace(/<svg\b[\s\S]*?<\/svg\s*>/gi, ' ');
 
   // Collect every candidate container body text — we take whichever
   // produces the longest clean output.

--- a/src/lib/article-fetch.ts
+++ b/src/lib/article-fetch.ts
@@ -51,23 +51,25 @@ export function extractArticleText(html: string): string {
   // Drop non-content blocks BEFORE tag-stripping so their contents
   // don't leak in.
   //
-  // Closing-tag pattern accepts optional whitespace + attribute-shaped
-  // garbage between the tag name and `>` (e.g. `</script >`,
-  // `</script\n>`, `</script foo>`). The HTML spec is permissive
-  // enough that real-world parsers tolerate these forms, and the
-  // strict `</script>` literal CodeQL flagged (#142, js/bad-tag-filter)
-  // would let an attacker smuggle a `<script>...</script foo>` block
-  // past the strip and into the LLM-prompt body.
+  // Closing-tag pattern uses `\b[^>]*>` so any non-`>` characters
+  // (whitespace, attributes, junk) between the tag name and `>` are
+  // accepted (e.g. `</script >`, `</script\t\n>`, `</script foo>`,
+  // `</script bar baz>`). HTML parsers tolerate all of these, and a
+  // strict `</script>` literal — or even `</script\s*>` (CodeQL
+  // #171) — lets an attacker smuggle a `<script>...</script foo>`
+  // block past the strip and into the LLM-prompt body when the
+  // attribute-shaped close is the only closing variant in the doc.
+  // The `\b` anchor blocks `</scripted>` collisions.
   const cleaned = html
-    .replace(/<script\b[\s\S]*?<\/script\s*>/gi, ' ')
-    .replace(/<style\b[\s\S]*?<\/style\s*>/gi, ' ')
-    .replace(/<noscript\b[\s\S]*?<\/noscript\s*>/gi, ' ')
-    .replace(/<nav\b[\s\S]*?<\/nav\s*>/gi, ' ')
-    .replace(/<header\b[\s\S]*?<\/header\s*>/gi, ' ')
-    .replace(/<footer\b[\s\S]*?<\/footer\s*>/gi, ' ')
-    .replace(/<aside\b[\s\S]*?<\/aside\s*>/gi, ' ')
-    .replace(/<form\b[\s\S]*?<\/form\s*>/gi, ' ')
-    .replace(/<svg\b[\s\S]*?<\/svg\s*>/gi, ' ');
+    .replace(/<script\b[\s\S]*?<\/script\b[^>]*>/gi, ' ')
+    .replace(/<style\b[\s\S]*?<\/style\b[^>]*>/gi, ' ')
+    .replace(/<noscript\b[\s\S]*?<\/noscript\b[^>]*>/gi, ' ')
+    .replace(/<nav\b[\s\S]*?<\/nav\b[^>]*>/gi, ' ')
+    .replace(/<header\b[\s\S]*?<\/header\b[^>]*>/gi, ' ')
+    .replace(/<footer\b[\s\S]*?<\/footer\b[^>]*>/gi, ' ')
+    .replace(/<aside\b[\s\S]*?<\/aside\b[^>]*>/gi, ' ')
+    .replace(/<form\b[\s\S]*?<\/form\b[^>]*>/gi, ' ')
+    .replace(/<svg\b[\s\S]*?<\/svg\b[^>]*>/gi, ' ');
 
   // Collect every candidate container body text — we take whichever
   // produces the longest clean output.

--- a/src/lib/discovery.ts
+++ b/src/lib/discovery.ts
@@ -129,7 +129,11 @@ export async function discoverTag(tag: string, env: Env): Promise<DiscoveredFeed
       });
       return [];
     }
-  } else if (typeof payloadRaw === 'object' && payloadRaw !== null) {
+  } else if (typeof payloadRaw === 'object') {
+    // The earlier `payloadRaw === null` early-return already excludes
+    // null, so the redundant runtime null check that was here was
+    // flagged by CodeQL #166 (js/comparison-between-incompatible-types)
+    // as comparing a non-nullable type to null.
     payload = payloadRaw as LLMDiscoveryPayload;
   } else {
     log('warn', 'discovery.completed', {

--- a/src/lib/html-text.ts
+++ b/src/lib/html-text.ts
@@ -14,11 +14,18 @@
  *  article HTML. Covers named entities, decimal `&#NNN;`, and hex
  *  `&#xHH;` numeric refs. Codepoints below 32 or above 0xFFFF are
  *  replaced with a single space (control chars + non-BMP — safe for
- *  prompt budgets). */
+ *  prompt budgets).
+ *
+ *  Order matters: `&amp;` is decoded LAST so an input like
+ *  `&amp;lt;` (the literal text representation of `&lt;`) does NOT
+ *  cascade into a real `<` after a downstream pass. CodeQL's
+ *  `js/double-escaping` rule flags the inverse order. Numeric refs
+ *  must also run before `&amp;` for the same reason — `&amp;#39;`
+ *  preserves its literal form rather than collapsing to an apostrophe.
+ */
 export function decodeHtmlEntities(input: string): string {
   return input
     .replace(/&nbsp;/g, ' ')
-    .replace(/&amp;/g, '&')
     .replace(/&lt;/g, '<')
     .replace(/&gt;/g, '>')
     .replace(/&quot;/g, '"')
@@ -42,7 +49,9 @@ export function decodeHtmlEntities(input: string): string {
       return Number.isFinite(code) && code >= 32 && code < 65536
         ? String.fromCharCode(code)
         : ' ';
-    });
+    })
+    // `&amp;` LAST — see comment above. CodeQL js/double-escaping #170.
+    .replace(/&amp;/g, '&');
 }
 
 /** Strip HTML tags, decode entities, collapse runs of whitespace.

--- a/tests/lib/html-text.test.ts
+++ b/tests/lib/html-text.test.ts
@@ -1,0 +1,85 @@
+// Tests for src/lib/html-text.ts — REQ-PIPE-001 / REQ-PIPE-002.
+//
+// Pins the entity-decoding contract for the scrape pipeline. The
+// most load-bearing assertion is the &amp;-LAST ordering that
+// closes CodeQL alert #170 (js/double-escaping): decoding &amp; first
+// would let an input like &amp;lt; cascade into a real `<` on the
+// next pass. The literal text "&lt;" (representing the characters
+// `&`, `l`, `t`, `;`) MUST survive the round-trip intact.
+
+import { describe, it, expect } from 'vitest';
+import { decodeHtmlEntities, stripHtmlToText } from '~/lib/html-text';
+
+describe('decodeHtmlEntities — REQ-PIPE-001', () => {
+  it('decodes the common named entity set', () => {
+    expect(decodeHtmlEntities('foo&nbsp;bar')).toBe('foo bar');
+    expect(decodeHtmlEntities('a&lt;b')).toBe('a<b');
+    expect(decodeHtmlEntities('a&gt;b')).toBe('a>b');
+    expect(decodeHtmlEntities('&quot;hi&quot;')).toBe('"hi"');
+    expect(decodeHtmlEntities('it&#39;s')).toBe("it's");
+    expect(decodeHtmlEntities('it&apos;s')).toBe("it's");
+    expect(decodeHtmlEntities('a&mdash;b')).toBe('a—b');
+    expect(decodeHtmlEntities('a&ndash;b')).toBe('a–b');
+    expect(decodeHtmlEntities('he said&hellip;')).toBe('he said…');
+  });
+
+  it('decodes a bare &amp; to a single ampersand', () => {
+    expect(decodeHtmlEntities('AT&amp;T')).toBe('AT&T');
+  });
+
+  it('decodes decimal numeric references', () => {
+    expect(decodeHtmlEntities('&#65;&#66;&#67;')).toBe('ABC');
+  });
+
+  it('decodes hex numeric references', () => {
+    expect(decodeHtmlEntities('&#x41;&#x42;')).toBe('AB');
+  });
+
+  it('replaces control-codepoints and non-BMP refs with a space', () => {
+    // Below 32 → space.
+    expect(decodeHtmlEntities('a&#1;b')).toBe('a b');
+    // Above 0xFFFF → space.
+    expect(decodeHtmlEntities('a&#x10000;b')).toBe('a b');
+  });
+
+  // CodeQL js/double-escaping #170 — the &amp;-LAST contract.
+  // If &amp; were decoded first, &amp;lt; would become &lt; and then
+  // the next pass would convert it to `<`. Decoding &amp; last keeps
+  // the literal text intact.
+  it('preserves literal "&lt;" when input is "&amp;lt;" (CodeQL #170)', () => {
+    expect(decodeHtmlEntities('&amp;lt;')).toBe('&lt;');
+    expect(decodeHtmlEntities('&amp;gt;')).toBe('&gt;');
+    expect(decodeHtmlEntities('&amp;quot;')).toBe('&quot;');
+  });
+
+  it('preserves literal "&#39;" when input is "&amp;#39;" (no double-decode)', () => {
+    // Numeric refs must also run before &amp; — otherwise &amp;#39;
+    // would collapse all the way to an apostrophe.
+    expect(decodeHtmlEntities('&amp;#39;')).toBe('&#39;');
+    expect(decodeHtmlEntities('&amp;#x41;')).toBe('&#x41;');
+  });
+
+  it('preserves "&amp;amp;" → "&amp;" (single-pass decode)', () => {
+    // Each call is one decode pass. Double-encoded ampersand decodes
+    // exactly one level.
+    expect(decodeHtmlEntities('&amp;amp;')).toBe('&amp;');
+  });
+});
+
+describe('stripHtmlToText — REQ-PIPE-002', () => {
+  it('strips tags, decodes entities, and collapses whitespace', () => {
+    expect(stripHtmlToText('<p>hello&nbsp;<b>world</b></p>')).toBe(
+      'hello world',
+    );
+  });
+
+  it('truncates to maxLength when supplied', () => {
+    expect(stripHtmlToText('<p>abcdefghij</p>', { maxLength: 5 })).toBe(
+      'abcde',
+    );
+  });
+
+  it('returns the trimmed full text when shorter than maxLength', () => {
+    expect(stripHtmlToText('<p>abc</p>', { maxLength: 100 })).toBe('abc');
+  });
+});

--- a/tests/pipeline/article-fetch.test.ts
+++ b/tests/pipeline/article-fetch.test.ts
@@ -88,6 +88,29 @@ describe('extractArticleText — REQ-PIPE-001 AC 8', () => {
     expect(text).not.toContain('Please enable JavaScript');
   });
 
+  // CodeQL js/bad-tag-filter #142 — the original strip regex required
+  // a literal `</script>` and missed `</script >` (with whitespace
+  // before the `>`) and `</script foo>` (with attribute-shaped junk).
+  // HTML parsers tolerate those forms, so attacker-controlled feed
+  // bodies could smuggle script content into the LLM-prompt body.
+  it('REQ-PIPE-001: strips script/style with whitespace and junk before the closing >', () => {
+    const html = `
+      <article>
+        Clean body text we do want.
+        <script>window.__leak1 = 1;</script >
+        <script>window.__leak2 = 2;</script\n>
+        <style>.x { color: red; }</style >
+        <script foo="bar">window.__leak3 = 3;</script bar>
+      </article>
+    `;
+    const text = extractArticleText(html);
+    expect(text).toContain('Clean body text');
+    expect(text).not.toMatch(/window\.__leak1/);
+    expect(text).not.toMatch(/window\.__leak2/);
+    expect(text).not.toMatch(/color: red/);
+    expect(text).not.toMatch(/window\.__leak3/);
+  });
+
   it('REQ-PIPE-001: falls back to <body> when no known container matches', () => {
     const html = `
       <html>

--- a/tests/pipeline/article-fetch.test.ts
+++ b/tests/pipeline/article-fetch.test.ts
@@ -88,11 +88,12 @@ describe('extractArticleText — REQ-PIPE-001 AC 8', () => {
     expect(text).not.toContain('Please enable JavaScript');
   });
 
-  // CodeQL js/bad-tag-filter #142 — the original strip regex required
-  // a literal `</script>` and missed `</script >` (with whitespace
-  // before the `>`) and `</script foo>` (with attribute-shaped junk).
-  // HTML parsers tolerate those forms, so attacker-controlled feed
-  // bodies could smuggle script content into the LLM-prompt body.
+  // CodeQL js/bad-tag-filter #142 / #171 — the original strip regex
+  // required a literal `</script>` and missed `</script >` (whitespace
+  // before the `>`), `</script\n>` (newline), and `</script foo>`
+  // (attribute-shaped junk). HTML parsers tolerate ALL these forms,
+  // so attacker-controlled feed bodies could smuggle script content
+  // into the LLM-prompt body. The fix uses `</script\b[^>]*>`.
   it('REQ-PIPE-001: strips script/style with whitespace and junk before the closing >', () => {
     const html = `
       <article>
@@ -109,6 +110,24 @@ describe('extractArticleText — REQ-PIPE-001 AC 8', () => {
     expect(text).not.toMatch(/window\.__leak2/);
     expect(text).not.toMatch(/color: red/);
     expect(text).not.toMatch(/window\.__leak3/);
+  });
+
+  // CodeQL #171 — isolates the case where the attribute-shaped close
+  // is the ONLY closing variant in the document (no later strict
+  // `</script>` for the lazy quantifier to fall through to). The
+  // earlier composite test had a trailing `</article>` that masked
+  // this branch — a stricter `</script\s*>` regex looked correct
+  // against the composite input but still let this fixture leak.
+  it('REQ-PIPE-001: strips a script when its attribute-shaped close is the ONLY closing variant', () => {
+    const html =
+      '<html><body>Article body that is plenty long to ground a summary across the threshold. ' +
+      '<script>window.__smuggle = 42;</script attr-only>' +
+      'Trailing prose that keeps the body candidate populated.</body></html>';
+    const text = extractArticleText(html);
+    expect(text).toContain('Article body that is plenty long');
+    expect(text).toContain('Trailing prose');
+    expect(text).not.toMatch(/window\.__smuggle/);
+    expect(text).not.toMatch(/= 42/);
   });
 
   it('REQ-PIPE-001: falls back to <body> when no known container matches', () => {


### PR DESCRIPTION
## Summary

Re-bases the work from #105 and #106 onto current `develop` (those PRs were CONFLICTING because they branched off pre-squash develop). Four cherry-picked commits, no logic changes:

- **CodeQL #170** (js/double-escaping) — reorder `decodeHtmlEntities` so `&amp;` decodes last; prevents `&amp;lt;` collapsing to `<`. Adds `tests/lib/html-text.test.ts`.
- **CodeQL #142** (js/bad-tag-filter, HIGH) — closing-tag regex in `extractArticleText` now accepts `</tag\s*>` and attribute-shaped junk for all 9 stripped block tags.
- **CodeQL #166** — drop dead `payloadRaw !== null` check in `discovery.ts:132` (TS narrowing already proves it).
- **Scorecard #20** — add `SECURITY.md` reporting policy.
- **CodeQL #171** (HIGH) — widens closing-tag regex further to `</tag\b[^>]*>` so attribute-shaped close (`</script foo>`) is matched even when it's the only closing variant. Earlier `\s*` form still missed that smuggle path.
- Cross-links `SECURITY.md` from `documentation/deployment.md` Related Documentation footer.

Supersedes #105 and #106.

## Test plan
- [ ] CI green (lint, typecheck, vitest)
- [ ] CodeQL alerts #170, #142, #166, #171 close on next scan
- [ ] Scorecard #20 (SecurityPolicyID) closes