### PR TITLE
fix(csp): serve page-effects + article-detail from /public

### DIFF
--- a/public/scripts/article-detail.js
+++ b/public/scripts/article-detail.js
@@ -1,0 +1,81 @@
+// Implements REQ-STAR-001, REQ-READ-002
+//
+// Article-detail page client behaviour. Served as a static file from
+// /public so CSP `script-src 'self'` permits it (Astro 5
+// directRenderScript inlines `<script>import './module';</script>` blocks
+// regardless of bundle size, and inline emits are blocked by the CSP).
+// The .ts source under src/scripts/article-detail.ts mirrors this file
+// and is kept for tests that read it via `?raw` imports.
+
+async function handleStarClick(button) {
+  const articleId = button.dataset.articleId;
+  if (articleId === undefined || articleId === '') return;
+  const wasPressed = button.getAttribute('aria-pressed') === 'true';
+  const nextPressed = !wasPressed;
+  button.setAttribute('aria-pressed', nextPressed ? 'true' : 'false');
+  try {
+    const res = await fetch(
+      `/api/articles/${encodeURIComponent(articleId)}/star`,
+      {
+        method: nextPressed ? 'POST' : 'DELETE',
+        credentials: 'same-origin',
+        headers: { 'Content-Type': 'application/json' },
+      },
+    );
+    if (!res.ok) {
+      button.setAttribute('aria-pressed', wasPressed ? 'true' : 'false');
+    }
+  } catch {
+    button.setAttribute('aria-pressed', wasPressed ? 'true' : 'false');
+  }
+}
+
+function initStar() {
+  if (document.documentElement.dataset.starDetailBound === '1') return;
+  document.documentElement.dataset.starDetailBound = '1';
+  document.addEventListener(
+    'click',
+    (e) => {
+      const target = e.target;
+      if (!(target instanceof Element)) return;
+      const button = target.closest('[data-star-toggle]');
+      if (button === null) return;
+      e.preventDefault();
+      e.stopPropagation();
+      void handleStarClick(button);
+    },
+    true,
+  );
+}
+
+function handleBackClick(e) {
+  if (e.button !== 0 || e.metaKey || e.ctrlKey || e.shiftKey || e.altKey) {
+    return;
+  }
+  const stateIndex = window.history.state?.index;
+  const arrivedInAppViaSpa =
+    typeof stateIndex === 'number' && stateIndex > 0;
+  const sameOriginReferrer =
+    document.referrer !== '' &&
+    new URL(document.referrer).origin === window.location.origin;
+  if (!arrivedInAppViaSpa && !sameOriginReferrer) {
+    return;
+  }
+  e.preventDefault();
+  window.history.back();
+}
+
+function bindBack() {
+  const link = document.querySelector('[data-article-back]');
+  if (link === null) return;
+  if (link.dataset.backBound === '1') return;
+  link.dataset.backBound = '1';
+  link.addEventListener('click', handleBackClick);
+}
+
+initStar();
+bindBack();
+document.addEventListener('astro:page-load', () => {
+  initStar();
+  bindBack();
+});

--- a/public/scripts/page-effects.js
+++ b/public/scripts/page-effects.js
@@ -1,0 +1,186 @@
+// Implements REQ-DES-002, REQ-DES-003, REQ-HIST-001, REQ-SET-007
+//
+// Layout-level client behaviour. Served as a static file from /public so
+// CSP `script-src 'self'` permits it (Astro 5 directRenderScript inlines
+// `<script>import './module';</script>` blocks regardless of size, and
+// every inline emit gets blocked by the CSP). The .ts source under
+// src/scripts/page-effects.ts mirrors this file and is kept for tests
+// that read it via `?raw` imports.
+
+async function syncBrowserTz() {
+  const body = document.body;
+  const stored = body.dataset.userTz ?? '';
+  if (stored !== '') return;
+  let browser = '';
+  try {
+    browser = Intl.DateTimeFormat().resolvedOptions().timeZone ?? '';
+  } catch {
+    return;
+  }
+  if (browser === '' || browser === stored) return;
+  try {
+    const res = await fetch('/api/auth/set-tz', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      credentials: 'same-origin',
+      body: JSON.stringify({ tz: browser }),
+    });
+    if (res.ok) {
+      body.dataset.userTz = browser;
+    }
+  } catch {
+    /* network hiccup — next page load will retry */
+  }
+}
+
+if (document.documentElement.dataset.tzAutoBound !== '1') {
+  document.documentElement.dataset.tzAutoBound = '1';
+  void syncBrowserTz();
+  document.addEventListener('astro:page-load', () => {
+    void syncBrowserTz();
+  });
+}
+
+let currentPath = window.location.pathname;
+const KEY = () => `scroll:${currentPath}`;
+
+function saveScroll() {
+  try {
+    sessionStorage.setItem(KEY(), String(window.scrollY));
+  } catch {
+    /* storage quota / disabled */
+  }
+}
+
+function restoreScroll() {
+  currentPath = window.location.pathname;
+  try {
+    const raw = sessionStorage.getItem(KEY());
+    if (raw === null) return;
+    const target = Number.parseInt(raw, 10);
+    if (!Number.isFinite(target) || target < 0) return;
+    if (target === 0) return;
+    const started = performance.now();
+    const DURATION_MS = 3000;
+    let cancelled = false;
+    let ro = null;
+    const teardown = () => {
+      cancelled = true;
+      if (ro !== null) {
+        ro.disconnect();
+        ro = null;
+      }
+    };
+    window.addEventListener('wheel', teardown, { once: true, passive: true });
+    window.addEventListener('touchmove', teardown, { once: true, passive: true });
+    if (typeof ResizeObserver !== 'undefined') {
+      ro = new ResizeObserver(() => {
+        if (cancelled) return;
+        window.scrollTo(0, target);
+      });
+      ro.observe(document.documentElement);
+    }
+    const tick = () => {
+      if (cancelled) return;
+      window.scrollTo(0, target);
+      if (performance.now() - started > DURATION_MS) {
+        teardown();
+        return;
+      }
+      requestAnimationFrame(tick);
+    };
+    requestAnimationFrame(tick);
+  } catch {
+    /* storage disabled */
+  }
+}
+
+function preFilterIncomingDocument(e) {
+  const ev = e;
+  const path = ev.to?.pathname ?? '';
+  if (path !== '/digest' && path !== '/history') return;
+  const raw = ev.to.searchParams.get('tags');
+  if (raw === null || raw === '') return;
+  const selected = new Set(
+    raw.split(',').map((t) => t.trim()).filter((t) => t !== ''),
+  );
+  if (selected.size === 0) return;
+  const doc = ev.newDocument;
+  if (doc === undefined) return;
+  doc.querySelectorAll('[data-digest-card]').forEach((card) => {
+    const cardTags = (card.dataset.tags ?? '').split(',').filter((t) => t !== '');
+    const match = cardTags.some((t) => selected.has(t));
+    if (!match) card.dataset.filterHide = '1';
+  });
+  doc.querySelectorAll('[data-tag-chip]').forEach((chip) => {
+    const tag = chip.dataset.tag;
+    if (tag !== undefined && selected.has(tag)) {
+      chip.classList.add('is-selected');
+      chip.setAttribute('aria-pressed', 'true');
+    }
+  });
+}
+
+function preOpenHistoryDayInIncomingDocument(e) {
+  const ev = e;
+  const path = ev.to?.pathname ?? '';
+  if (path !== '/history') return;
+  if (ev.to.searchParams.has('date')) return;
+  let raw = null;
+  try {
+    raw = sessionStorage.getItem('history:last-day-state');
+  } catch {
+    return;
+  }
+  if (raw === null || raw === '') return;
+  let parsed = {};
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return;
+  }
+  const date = parsed.date;
+  if (typeof date !== 'string' || date === '') return;
+  const doc = ev.newDocument;
+  if (doc === undefined) return;
+  const day = doc.querySelector(
+    `[data-history-day][data-date="${CSS.escape(date)}"]`,
+  );
+  if (day === null) return;
+  const det = day.querySelector('.history__details');
+  if (det === null) return;
+  det.open = true;
+}
+
+if (document.documentElement.dataset.scrollRestoreBound !== '1') {
+  document.documentElement.dataset.scrollRestoreBound = '1';
+  if ('scrollRestoration' in window.history) {
+    window.history.scrollRestoration = 'manual';
+  }
+  document.addEventListener('astro:before-swap', preFilterIncomingDocument);
+  document.addEventListener('astro:before-swap', preOpenHistoryDayInIncomingDocument);
+  document.addEventListener('astro:before-swap', saveScroll);
+  document.addEventListener('astro:after-swap', () => {
+    try {
+      const raw = sessionStorage.getItem(`scroll:${window.location.pathname}`);
+      if (raw === null) return;
+      const target = Number.parseInt(raw, 10);
+      if (!Number.isFinite(target) || target <= 0) return;
+      window.scrollTo(0, target);
+    } catch {
+      /* storage disabled */
+    }
+  });
+  document.addEventListener('astro:before-preparation', () => {
+    document.documentElement.dataset.vtActive = '1';
+  });
+  document.addEventListener('astro:after-swap', () => {
+    delete document.documentElement.dataset.vtActive;
+  });
+  window.addEventListener('pagehide', saveScroll);
+  document.addEventListener('astro:page-load', restoreScroll);
+  window.addEventListener('pageshow', (e) => {
+    if (e.persisted) restoreScroll();
+  });
+  restoreScroll();
+}

--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -246,9 +246,14 @@ const initialTheme = cookieTheme ?? 'light';
           - Sync after-swap scroll restore so below-fold cards land
             inside the new-page snapshot (REQ-DES-003 / REQ-HIST-001).
           - data-vt-active flag for header opacity. */}
-    <script>
-      import '~/scripts/page-effects';
-    </script>
+    {/* Astro 5 directRenderScript inlines the bundled output of any
+        <script>import '...';</script> block regardless of size, which
+        the site's `script-src 'self'` CSP then blocks at runtime. The
+        only reliable workaround is a static-served file in /public
+        loaded via is:inline (Astro renders the tag verbatim, no
+        processing). The .ts source under src/scripts/page-effects.ts
+        mirrors this file. */}
+    <script is:inline type="module" src="/scripts/page-effects.js"></script>
 
     {/* Scroll save/restore + view-transition handlers also live in
         ~/scripts/page-effects (imported above). The previous inline

--- a/src/pages/digest/[id]/[slug].astro
+++ b/src/pages/digest/[id]/[slug].astro
@@ -619,12 +619,10 @@ const articleDataset = {
   }
 </style>
 
-<script>
-  // The site's CSP is `script-src 'self'` — Astro inlines small page-
-  // level scripts directly into the HTML, and the browser blocks them
-  // as inline-CSP violations. This `import` makes Astro bundle the
-  // module externally instead, so it loads as `<script src="...">`
-  // and actually executes. See src/scripts/article-detail.ts for the
-  // star-toggle + back-button logic that lives in the bundle.
-  import '~/scripts/article-detail';
-</script>
+{/* Astro 5 directRenderScript inlines the bundled output of any
+    <script>import '...';</script> block regardless of size, which the
+    site's `script-src 'self'` CSP then blocks at runtime. The only
+    reliable workaround is a static-served file in /public loaded via
+    is:inline (Astro renders the tag verbatim, no processing). The .ts
+    source under src/scripts/article-detail.ts mirrors this file. */}
+<script is:inline type="module" src="/scripts/article-detail.js"></script>

--- a/tests/layouts/base.test.ts
+++ b/tests/layouts/base.test.ts
@@ -21,13 +21,16 @@ import baseSource from '../../src/layouts/Base.astro?raw';
 import effectsSource from '../../src/scripts/page-effects.ts?raw';
 
 describe('Base.astro / page-effects.ts — view-transition wiring (REQ-DES-003 / REQ-HIST-001)', () => {
-  it('Base.astro imports the external page-effects module so CSP allows the script', () => {
-    // The site CSP is `script-src 'self'` — inline `<script>` bodies
-    // are blocked. Astro bundles imports into external `<script src>`
-    // tags which CSP allows from the same origin. Lose this import
-    // and every behaviour below silently disappears at runtime.
+  it('Base.astro references /scripts/page-effects.js as a static-served module so CSP allows it', () => {
+    // The site CSP is `script-src 'self'`. Astro 5 directRenderScript
+    // INLINES `<script>import './module';</script>` bundles regardless
+    // of size, and the inline emit is then blocked at runtime. The
+    // workaround is to reference public/scripts/page-effects.js with
+    // is:inline so Astro renders the tag verbatim — no processing, no
+    // inlining, just a same-origin <script src=> the browser fetches
+    // straight from the static asset pipeline.
     expect(baseSource).toMatch(
-      /<script>\s*import\s+['"]~\/scripts\/page-effects['"]\s*;?\s*<\/script>/,
+      /<script\s+is:inline\s+type="module"\s+src="\/scripts\/page-effects\.js"\s*>\s*<\/script>/,
     );
   });
 

--- a/tests/reading/detail-page.test.ts
+++ b/tests/reading/detail-page.test.ts
@@ -101,17 +101,17 @@ describe('detail page source contract — REQ-READ-002', () => {
     expect(detailSource).toMatch(/href="\/digest"/);
   });
 
-  it('REQ-READ-002: page imports the external article-detail module (CSP-compatible)', () => {
-    // The site CSP is `script-src 'self'`. Inline `<script>` bodies
-    // (which Astro emits when a page-level script has no imports)
-    // are blocked at runtime — bindBack never ran on the live site,
-    // so the in-UI back arrow always fell through to its static
-    // `href="/digest"` fallback regardless of the hijack logic.
-    // Importing the module forces Astro to bundle it as
-    // `<script type="module" src="...">`, which CSP allows from
-    // the same origin.
+  it('REQ-READ-002: page references /scripts/article-detail.js as a static-served module (CSP-compatible)', () => {
+    // Astro 5 directRenderScript INLINES `<script>import './module';</script>`
+    // bundles regardless of size, and the site's `script-src 'self'`
+    // CSP blocks every inline emit. Pinning is:inline + a static
+    // public/scripts file is the only configuration that survives
+    // both Astro's processing and CSP at runtime — bindBack actually
+    // executes, the in-UI back arrow's hijack works, and the
+    // href="/digest" fallback only fires for genuine direct-link
+    // visits.
     expect(detailSource).toMatch(
-      /<script>\s*[\s\S]*import\s+['"]~\/scripts\/article-detail['"]\s*;?\s*[\s\S]*<\/script>/,
+      /<script\s+is:inline\s+type="module"\s+src="\/scripts\/article-detail\.js"\s*>\s*<\/script>/,
     );
   });
 


### PR DESCRIPTION
## Summary
- Astro 5 directRenderScript silently inlines bundled output of `<script>import './module';</script>` blocks regardless of size, then the site CSP `script-src 'self'` blocks the inline emit. Verified empirically with Playwright on the live site: securitypolicyviolation events reported `script-src-elem blocked inline`, and `[data-article-back].dataset.backBound` was never set.
- Workaround: write the JS bodies to `public/scripts/{page-effects,article-detail}.js` and load them via `<script is:inline type="module" src="/scripts/...js">`. is:inline tells Astro to render the tag verbatim, no processing — the browser fetches the static file from same origin and CSP allows it.
- The .ts originals in `src/scripts/` are kept untouched as the canonical reference for the body-content `?raw` test assertions.

## Test plan
- [x] CI green
- [ ] Cloudflare auto-deploy succeeds
- [ ] Playwright re-run on https://news.graymatter.ch confirms (a) `[data-article-back].dataset.backBound === '1'` after page load, (b) clicking the back arrow navigates back, (c) /history morph plays on browser back from a below-fold card