### PR TITLE
fix(csp): static-serve all 6 page scripts + dodge knip

### DIFF
--- a/public/scripts/alt-sources-modal.js
+++ b/public/scripts/alt-sources-modal.js
@@ -1,0 +1,80 @@
+// Implements REQ-READ-002 — alt-sources modal open/close.
+// Static-served because Astro 5 directRenderScript inlines pure-import
+// script tags and the site CSP `script-src 'self'` blocks the inline
+// emit. The .ts source under src/scripts/alt-sources-modal.ts mirrors
+// this file.
+
+function getDialog() {
+  return document.querySelector('[data-alt-sources-modal]');
+}
+
+function onTriggerClick(event) {
+  const dialog = getDialog();
+  if (dialog === null) return;
+  event.preventDefault();
+  if (typeof dialog.showModal === 'function') {
+    dialog.showModal();
+  }
+}
+
+function onCloseClick(event) {
+  const dialog = getDialog();
+  if (dialog === null) return;
+  event.preventDefault();
+  if (typeof dialog.close === 'function') {
+    dialog.close();
+  }
+}
+
+function onDialogClick(event) {
+  const dialog = getDialog();
+  if (dialog === null) return;
+  if (event.target === dialog) {
+    dialog.close();
+  }
+}
+
+function initModal() {
+  const dialog = getDialog();
+  if (dialog === null) return;
+  if (dialog.dataset.bound === '1') return;
+  dialog.dataset.bound = '1';
+
+  const triggers = document.querySelectorAll('[data-alt-sources-trigger]');
+  triggers.forEach((t) => {
+    t.addEventListener('click', onTriggerClick);
+  });
+
+  const closeBtn = dialog.querySelector('[data-alt-sources-close]');
+  if (closeBtn !== null) {
+    closeBtn.addEventListener('click', onCloseClick);
+  }
+
+  dialog.addEventListener('click', onDialogClick);
+}
+
+function teardownModal() {
+  const dialog = getDialog();
+  if (dialog === null) return;
+
+  const triggers = document.querySelectorAll('[data-alt-sources-trigger]');
+  triggers.forEach((t) => {
+    t.removeEventListener('click', onTriggerClick);
+  });
+
+  const closeBtn = dialog.querySelector('[data-alt-sources-close]');
+  if (closeBtn !== null) {
+    closeBtn.removeEventListener('click', onCloseClick);
+  }
+
+  dialog.removeEventListener('click', onDialogClick);
+  dialog.dataset.bound = '0';
+}
+
+if (document.readyState === 'loading') {
+  document.addEventListener('DOMContentLoaded', initModal, { once: true });
+} else {
+  initModal();
+}
+document.addEventListener('astro:page-load', initModal);
+document.addEventListener('astro:before-swap', teardownModal);

--- a/public/scripts/install-prompt.js
+++ b/public/scripts/install-prompt.js
@@ -1,0 +1,89 @@
+// Implements REQ-PWA-001 AC 4, AC 5
+//
+// Static-served because Astro 5 directRenderScript inlines the bundled
+// output of `<script>import './module';</script>` blocks, and the site
+// CSP `script-src 'self'` blocks the inline emit. The .ts source under
+// src/scripts/install-prompt.ts mirrors this file.
+
+const IOS_UA_PATTERN = /iPad|iPhone|iPod/;
+const IOS_PROMPT_SEEN_KEY = 'pwa.iosInstallNoteSeen';
+
+function isStandalone() {
+  if (typeof window === 'undefined') return false;
+  if (window.matchMedia && window.matchMedia('(display-mode: standalone)').matches) {
+    return true;
+  }
+  const nav = window.navigator;
+  return nav.standalone === true;
+}
+
+function isIos() {
+  if (typeof navigator === 'undefined') return false;
+  const nav = navigator;
+  return IOS_UA_PATTERN.test(nav.userAgent) && !nav.standalone;
+}
+
+function initInstallPrompt() {
+  const root = document.querySelector('[data-install-prompt]');
+  if (!root) return;
+  if (isStandalone()) return;
+
+  const button = root.querySelector('[data-install-button]');
+  const iosNote = root.querySelector('[data-install-ios-note]');
+
+  if (isIos() && iosNote) {
+    let seen = false;
+    try {
+      seen = window.localStorage.getItem(IOS_PROMPT_SEEN_KEY) === '1';
+    } catch {
+      seen = false;
+    }
+    if (!seen) {
+      root.hidden = false;
+      iosNote.hidden = false;
+      try {
+        window.localStorage.setItem(IOS_PROMPT_SEEN_KEY, '1');
+      } catch {
+        /* ignore */
+      }
+    }
+    return;
+  }
+
+  let deferredPrompt = null;
+
+  window.addEventListener('beforeinstallprompt', (event) => {
+    event.preventDefault();
+    deferredPrompt = event;
+    if (button) {
+      root.hidden = false;
+      button.hidden = false;
+    }
+  });
+
+  if (button) {
+    button.addEventListener('click', async () => {
+      if (!deferredPrompt) return;
+      try {
+        await deferredPrompt.prompt();
+        await deferredPrompt.userChoice;
+      } finally {
+        deferredPrompt = null;
+        button.hidden = true;
+        root.hidden = true;
+      }
+    });
+  }
+
+  window.addEventListener('appinstalled', () => {
+    deferredPrompt = null;
+    if (button) button.hidden = true;
+    root.hidden = true;
+  });
+}
+
+if (document.readyState === 'loading') {
+  document.addEventListener('DOMContentLoaded', initInstallPrompt, { once: true });
+} else {
+  initInstallPrompt();
+}

--- a/public/scripts/offline.js
+++ b/public/scripts/offline.js
@@ -1,0 +1,26 @@
+// Implements REQ-READ-006 — offline retry button + online-event hop.
+// Static-served because Astro 5 directRenderScript inlines pure-import
+// script tags and the site CSP `script-src 'self'` blocks the inline
+// emit. The .ts source under src/scripts/offline.ts mirrors this file.
+
+function init() {
+  const button = document.querySelector('[data-offline-retry]');
+  if (button === null) return;
+  if (button.dataset.bound === '1') return;
+  button.dataset.bound = '1';
+  button.addEventListener('click', () => {
+    if (window.navigator.onLine) {
+      window.location.assign('/digest');
+    }
+  });
+  window.addEventListener('online', () => {
+    window.location.assign('/digest');
+  });
+}
+
+if (document.readyState === 'loading') {
+  document.addEventListener('DOMContentLoaded', init, { once: true });
+} else {
+  init();
+}
+document.addEventListener('astro:page-load', init);

--- a/public/scripts/rate-limited.js
+++ b/public/scripts/rate-limited.js
@@ -1,0 +1,56 @@
+// Implements REQ-AUTH-001 — countdown + button re-enable on the rate-limited page.
+// Static-served because Astro 5 directRenderScript inlines pure-import
+// script tags and the site CSP `script-src 'self'` blocks the inline
+// emit. The .ts source under src/scripts/rate-limited.ts mirrors this
+// file.
+
+function formatRemaining(seconds) {
+  const h = Math.floor(seconds / 3600);
+  const m = Math.floor((seconds % 3600) / 60);
+  const s = seconds % 60;
+  if (h > 0) return `${h}h ${m}m`;
+  return `${m}m ${s}s`;
+}
+
+function init() {
+  const root = document.querySelector('[data-rate-limited]');
+  if (root === null) return;
+  if (root.dataset.bound === '1') return;
+  root.dataset.bound = '1';
+
+  const raw = root.dataset.seconds;
+  if (raw === undefined || raw === '') return;
+  const initial = Number.parseInt(raw, 10);
+  if (Number.isNaN(initial)) return;
+
+  const countdown = root.querySelector('[data-countdown]');
+  const button = root.querySelector('[data-retry-button]');
+
+  const deadline = Math.floor(Date.now() / 1000) + initial;
+  const tick = () => {
+    const remaining = Math.max(0, deadline - Math.floor(Date.now() / 1000));
+    if (countdown !== null) countdown.textContent = formatRemaining(remaining);
+    if (remaining <= 0) {
+      if (button !== null) button.disabled = false;
+      window.clearInterval(handle);
+    }
+  };
+
+  const handle = window.setInterval(tick, 1000);
+  tick();
+
+  if (button !== null) {
+    button.addEventListener('click', () => {
+      if (!button.disabled) {
+        window.location.assign('/digest');
+      }
+    });
+  }
+}
+
+if (document.readyState === 'loading') {
+  document.addEventListener('DOMContentLoaded', init, { once: true });
+} else {
+  init();
+}
+document.addEventListener('astro:page-load', init);

--- a/src/components/AltSourcesModal.astro
+++ b/src/components/AltSourcesModal.astro
@@ -122,12 +122,12 @@ const primaryIso = toIsoDatetime(primaryPublishedAt);
   </div>
 </dialog>
 
-<script>
-  // Logic moved to src/scripts/alt-sources-modal.ts so Astro emits an
-  // external bundle (CSP `script-src 'self'` blocks the inline
-  // bundle Astro would otherwise produce for small scripts).
-  import '~/scripts/alt-sources-modal';
-</script>
+{/* Static-served from /public so the site CSP `script-src 'self'`
+    permits it. Astro 5 directRenderScript inlines pure-import script
+    tags regardless of size, and the inline emit is then blocked by
+    CSP. The .ts source under src/scripts/alt-sources-modal.ts mirrors
+    this file. */}
+<script is:inline type="module" src="/scripts/alt-sources-modal.js"></script>
 
 <style>
   /* Editorial modal: serif heading, small-caps metadata line inside

--- a/src/components/InstallPrompt.astro
+++ b/src/components/InstallPrompt.astro
@@ -53,12 +53,12 @@ const { class: className = '' } = Astro.props;
   </p>
 </div>
 
-<script>
-  // Logic moved to src/scripts/install-prompt.ts so Astro emits an
-  // external bundle (CSP `script-src 'self'` blocks the inline
-  // bundle Astro would otherwise produce for small scripts).
-  import '~/scripts/install-prompt';
-</script>
+{/* Static-served from /public so the site CSP `script-src 'self'`
+    permits it. Astro 5 directRenderScript inlines pure-import script
+    tags regardless of size, and the inline emit is then blocked by
+    CSP. The .ts source under src/scripts/install-prompt.ts mirrors
+    this file. */}
+<script is:inline type="module" src="/scripts/install-prompt.js"></script>
 
 <style>
   .install-prompt {

--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -247,12 +247,12 @@ const initialTheme = cookieTheme ?? 'light';
             inside the new-page snapshot (REQ-DES-003 / REQ-HIST-001).
           - data-vt-active flag for header opacity. */}
     {/* Astro 5 directRenderScript inlines the bundled output of any
-        <script>import '...';</script> block regardless of size, which
-        the site's `script-src 'self'` CSP then blocks at runtime. The
-        only reliable workaround is a static-served file in /public
-        loaded via is:inline (Astro renders the tag verbatim, no
-        processing). The .ts source under src/scripts/page-effects.ts
-        mirrors this file. */}
+        pure-import script tag regardless of size, which the site's
+        `script-src 'self'` CSP then blocks at runtime. The only
+        reliable workaround is a static-served file in /public loaded
+        via is:inline (Astro renders the tag verbatim, no processing).
+        The .ts source under src/scripts/page-effects.ts mirrors this
+        file. */}
     <script is:inline type="module" src="/scripts/page-effects.js"></script>
 
     {/* Scroll save/restore + view-transition handlers also live in

--- a/src/pages/digest/[id]/[slug].astro
+++ b/src/pages/digest/[id]/[slug].astro
@@ -620,9 +620,9 @@ const articleDataset = {
 </style>
 
 {/* Astro 5 directRenderScript inlines the bundled output of any
-    <script>import '...';</script> block regardless of size, which the
-    site's `script-src 'self'` CSP then blocks at runtime. The only
-    reliable workaround is a static-served file in /public loaded via
+    pure-import script tag regardless of size, which the site's
+    `script-src 'self'` CSP then blocks at runtime. The only reliable
+    workaround is a static-served file in /public loaded via
     is:inline (Astro renders the tag verbatim, no processing). The .ts
     source under src/scripts/article-detail.ts mirrors this file. */}
 <script is:inline type="module" src="/scripts/article-detail.js"></script>

--- a/src/pages/offline.astro
+++ b/src/pages/offline.astro
@@ -34,12 +34,12 @@ import Base from '~/layouts/Base.astro';
   </section>
 </Base>
 
-<script>
-  // Logic moved to src/scripts/offline.ts so Astro emits an
-  // external bundle (CSP `script-src 'self'` blocks the inline
-  // bundle Astro would otherwise produce for small scripts).
-  import '~/scripts/offline';
-</script>
+{/* Static-served from /public so the site CSP `script-src 'self'`
+    permits it. Astro 5 directRenderScript inlines pure-import script
+    tags regardless of size, and the inline emit is then blocked by
+    CSP. The .ts source under src/scripts/offline.ts mirrors this
+    file. */}
+<script is:inline type="module" src="/scripts/offline.js"></script>
 
 <style>
   .offline-page {

--- a/src/pages/rate-limited.astro
+++ b/src/pages/rate-limited.astro
@@ -50,12 +50,12 @@ const initialLabel = hours > 0 ? `${hours}h ${minutes}m` : `${minutes}m ${secs}s
   </section>
 </Base>
 
-<script>
-  // Logic moved to src/scripts/rate-limited.ts so Astro emits an
-  // external bundle (CSP `script-src 'self'` blocks the inline
-  // bundle Astro would otherwise produce for small scripts).
-  import '~/scripts/rate-limited';
-</script>
+{/* Static-served from /public so the site CSP `script-src 'self'`
+    permits it. Astro 5 directRenderScript inlines pure-import script
+    tags regardless of size, and the inline emit is then blocked by
+    CSP. The .ts source under src/scripts/rate-limited.ts mirrors this
+    file. */}
+<script is:inline type="module" src="/scripts/rate-limited.js"></script>
 
 <style>
   .rate-limited {


### PR DESCRIPTION
## Summary
Round 3. Extends the public/scripts/*.js + is:inline pattern to the four remaining inline-import scripts (install-prompt, alt-sources-modal, offline, rate-limited) so their behaviour also survives the site CSP `script-src 'self'`. Also tweaks the comments in Base.astro and slug.astro to drop a literal `<script>import '...';</script>` substring that knip's parser was mistakenly treating as a real import — that's why develop CI failed the dead-code gate after PR #116.

The .ts originals under src/scripts/ are kept as the canonical reference for the existing tests; the runtime is now exclusively the public/scripts/*.js files.

## Test plan
- [x] CI green
- [ ] Cloudflare deploy succeeds on merge
- [ ] Playwright on https://news.graymatter.ch confirms back-button hijack works and /history morph plays