### PR TITLE
docs(readme): correct cross-provider email merging blurb

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ News Digest hires the LLM. It remembers so you don't. This isn't enlightenment. 
 - **Hallucinations dropped on sight**: every LLM output has to point back to a real source, or it doesn't touch the database. Ask me how I learned that.
 - **Daily digest email** (optional): fresh headlines when there's news, a brief hello when there isn't. Once per day in your timezone — the cadence is the point.
 - **Starred articles outlive the cron**: 14-day retention, unless you starred it. Your saved list is forever; your unread list was a lie anyway.
-- **Federated sign-in**: GitHub or Google. Wire up one, both, or neither — the app tells the truth either way. No cross-provider email merging, because auth systems have enough ways to disappoint you.
+- **Federated sign-in**: GitHub or Google. Wire up one, both, or neither — the app tells the truth either way. Same verified email across both providers now lands in one account (the daily digest goes out once, not twice), with a one-time backfill that re-points stars, read marks, and pending discoveries from the duplicates to the survivor.
 - **Looks like a real product when shared**: paste the URL into iMessage, WhatsApp, Slack, LinkedIn, or Discord — you get a brand card, not a naked URL. Surprisingly hard. Don't ask.
 - **One Worker, no servers**: Cloudflare D1 + KV + Queues + Workers AI. Ships in 30 seconds. Rollback is `wrangler rollback`, which I've used more times than I'd like to admit.
 


### PR DESCRIPTION
REQ-AUTH-007 made same-verified-email accounts merge. The README was still claiming 'no cross-provider email merging' which is now false. One-line fix to match the actual product behaviour.

## Test plan
- [x] CI green
- [ ] Cloudflare deploy succeeds on merge to main