### PR TITLE
test: pin script tag attributes independently of order

### DIFF
--- a/tests/layouts/base.test.ts
+++ b/tests/layouts/base.test.ts
@@ -29,9 +29,15 @@ describe('Base.astro / page-effects.ts — view-transition wiring (REQ-DES-003 /
     // is:inline so Astro renders the tag verbatim — no processing, no
     // inlining, just a same-origin <script src=> the browser fetches
     // straight from the static asset pipeline.
-    expect(baseSource).toMatch(
-      /<script\s+is:inline\s+type="module"\s+src="\/scripts\/page-effects\.js"\s*>\s*<\/script>/,
-    );
+    //
+    // Pin attributes independently so a prettier or hand reorder
+    // (alphabetical, etc.) doesn't break the test on a no-op format
+    // commit.
+    const tag = baseSource.match(/<script\b[^>]*src="\/scripts\/page-effects\.js"[^>]*>\s*<\/script>/);
+    expect(tag, 'expected a <script src="/scripts/page-effects.js"> tag in Base.astro').not.toBeNull();
+    const t = tag?.[0] ?? '';
+    expect(t).toMatch(/\bis:inline\b/);
+    expect(t).toMatch(/type="module"/);
   });
 
   it('page-effects.ts registers preOpenHistoryDayInIncomingDocument as an astro:before-swap listener', () => {

--- a/tests/reading/detail-page.test.ts
+++ b/tests/reading/detail-page.test.ts
@@ -110,9 +110,15 @@ describe('detail page source contract — REQ-READ-002', () => {
     // executes, the in-UI back arrow's hijack works, and the
     // href="/digest" fallback only fires for genuine direct-link
     // visits.
-    expect(detailSource).toMatch(
-      /<script\s+is:inline\s+type="module"\s+src="\/scripts\/article-detail\.js"\s*>\s*<\/script>/,
-    );
+    //
+    // Pin attributes independently so a prettier or hand reorder
+    // (alphabetical, etc.) doesn't break the test on a no-op format
+    // commit.
+    const tag = detailSource.match(/<script\b[^>]*src="\/scripts\/article-detail\.js"[^>]*>\s*<\/script>/);
+    expect(tag, 'expected a <script src="/scripts/article-detail.js"> tag in [slug].astro').not.toBeNull();
+    const t = tag?.[0] ?? '';
+    expect(t).toMatch(/\bis:inline\b/);
+    expect(t).toMatch(/type="module"/);
   });
 
   it('REQ-READ-002: article-detail.ts back-button hijack uses both SPA-nav and same-origin signals', () => {


### PR DESCRIPTION
Reviewer HIGH on PR #120 — the new is:inline regex was order-locked, which would fail on a no-op prettier reorder. Match by src then assert is:inline + type=module separately.

## Test plan
- [x] CI green