### PR TITLE
fix(email): warmer greeting copy with N=1/N>1 grammar

### DIFF
--- a/src/lib/email.ts
+++ b/src/lib/email.ts
@@ -181,7 +181,7 @@ export function renderDigestReadyEmail(params: DigestReadyEmailParams): Rendered
   if (headlines.length === 0) {
     textLines.push('Your news digest is ready.');
   } else {
-    textLines.push(`Your news digest is ready. ${headlines.length} new ${articleNoun} to read.`);
+    textLines.push(`Your news digest is ready. Here are your ${headlines.length} latest ${articleNoun}.`);
   }
   textLines.push('');
   if (headlines.length > 0) {
@@ -255,7 +255,7 @@ export function renderDigestReadyEmail(params: DigestReadyEmailParams): Rendered
   const greetingRow = headlines.length === 0
     ? `<tr><td style="padding-bottom:24px; font-size:20px; line-height:1.4; font-weight:500;">Your news digest is ready.</td></tr>`
     : `<tr><td style="padding-bottom:20px; font-size:20px; line-height:1.4; font-weight:500;">
-         Your news digest is ready. ${headlines.length} new ${articleNoun} to read.
+         Your news digest is ready. Here are your ${headlines.length} latest ${articleNoun}.
        </td></tr>`;
 
   const html = `<!doctype html>

--- a/src/lib/email.ts
+++ b/src/lib/email.ts
@@ -181,7 +181,11 @@ export function renderDigestReadyEmail(params: DigestReadyEmailParams): Rendered
   if (headlines.length === 0) {
     textLines.push('Your news digest is ready.');
   } else {
-    textLines.push(`Your news digest is ready. Here are your ${headlines.length} latest ${articleNoun}.`);
+    textLines.push(
+      headlines.length === 1
+        ? 'Your news digest is ready. Here is your latest article.'
+        : `Your news digest is ready. Here are your ${headlines.length} latest articles.`,
+    );
   }
   textLines.push('');
   if (headlines.length > 0) {
@@ -252,10 +256,16 @@ export function renderDigestReadyEmail(params: DigestReadyEmailParams): Rendered
         Built with <a href="${escapeHtml(CODEFLARE_URL)}" style="color:#888; text-decoration:none;">Codeflare</a> &copy; 2026 <a href="${escapeHtml(GRAY_MATTER_URL)}" style="color:#888; text-decoration:none;">Gray Matter GmbH</a>
       </td></tr>`;
 
+  const greetingBodyText =
+    headlines.length === 0
+      ? 'Your news digest is ready.'
+      : headlines.length === 1
+        ? 'Your news digest is ready. Here is your latest article.'
+        : `Your news digest is ready. Here are your ${headlines.length} latest articles.`;
   const greetingRow = headlines.length === 0
-    ? `<tr><td style="padding-bottom:24px; font-size:20px; line-height:1.4; font-weight:500;">Your news digest is ready.</td></tr>`
+    ? `<tr><td style="padding-bottom:24px; font-size:20px; line-height:1.4; font-weight:500;">${greetingBodyText}</td></tr>`
     : `<tr><td style="padding-bottom:20px; font-size:20px; line-height:1.4; font-weight:500;">
-         Your news digest is ready. Here are your ${headlines.length} latest ${articleNoun}.
+         ${greetingBodyText}
        </td></tr>`;
 
   const html = `<!doctype html>

--- a/tests/email/render.test.ts
+++ b/tests/email/render.test.ts
@@ -87,19 +87,23 @@ describe('renderDigestReadyEmail subject — REQ-MAIL-001 AC 3', () => {
     expect(subject).not.toContain('1 new articles');
   });
 
-  it('REQ-MAIL-001 AC 3: HTML and plain-text greeting also pluralise correctly when N=1', () => {
+  it('REQ-MAIL-001 AC 3: greeting uses singular grammar when N=1 ("Here is your latest article.")', () => {
     const single: Headline = FIVE_HEADLINES[0]!;
     const { html, text } = renderDigestReadyEmail(makeParams({
       headlines: [single],
       tagTally: [{ tag: 'mcp', count: 1 }],
     }));
-    expect(html).toContain('Here are your 1 latest article.');
-    expect(html).not.toContain('Here are your 1 latest articles.');
-    expect(text).toContain('Here are your 1 latest article.');
-    expect(text).not.toContain('Here are your 1 latest articles.');
+    // Verb agrees with N=1, count is dropped (would be "1 latest article" — redundant).
+    expect(html).toContain('Here is your latest article.');
+    expect(text).toContain('Here is your latest article.');
+    // The plural form must NOT leak into the N=1 path.
+    expect(html).not.toContain('Here are your');
+    expect(text).not.toContain('Here are your');
+    expect(html).not.toContain('latest articles');
+    expect(text).not.toContain('latest articles');
   });
 
-  it('REQ-MAIL-001 AC 3: greeting reads "Here are your N latest articles" for N>1', () => {
+  it('REQ-MAIL-001 AC 3: greeting uses plural grammar when N>1 ("Here are your N latest articles.")', () => {
     const { html, text } = renderDigestReadyEmail(makeParams());
     expect(html).toContain('Here are your 5 latest articles.');
     expect(text).toContain('Here are your 5 latest articles.');

--- a/tests/email/render.test.ts
+++ b/tests/email/render.test.ts
@@ -93,10 +93,19 @@ describe('renderDigestReadyEmail subject — REQ-MAIL-001 AC 3', () => {
       headlines: [single],
       tagTally: [{ tag: 'mcp', count: 1 }],
     }));
-    expect(html).toContain('1 new article to read');
-    expect(html).not.toContain('1 new articles to read');
-    expect(text).toContain('1 new article to read');
-    expect(text).not.toContain('1 new articles to read');
+    expect(html).toContain('Here are your 1 latest article.');
+    expect(html).not.toContain('Here are your 1 latest articles.');
+    expect(text).toContain('Here are your 1 latest article.');
+    expect(text).not.toContain('Here are your 1 latest articles.');
+  });
+
+  it('REQ-MAIL-001 AC 3: greeting reads "Here are your N latest articles" for N>1', () => {
+    const { html, text } = renderDigestReadyEmail(makeParams());
+    expect(html).toContain('Here are your 5 latest articles.');
+    expect(text).toContain('Here are your 5 latest articles.');
+    // The previous wording is gone.
+    expect(html).not.toContain('5 new articles to read');
+    expect(text).not.toContain('5 new articles to read');
   });
 });
 


### PR DESCRIPTION
## Summary
- Email body greeting changed from "{N} new articles to read." to:
  - N>1: "Here are your {N} latest articles."
  - N=1: "Here is your latest article."
- Verb-number agreement in both branches; the count is dropped in the N=1 branch since "1 latest article" reads redundantly.
- HTML and plain-text bodies updated; tests pin both forms.

## Test plan
- [x] Unit tests pin singular greeting for N=1 and plural for N>1.
- [ ] Production verify: trigger a digest send and confirm greeting reads naturally for both branches.