### PR TITLE
fix(header): solid base background to stop scroll content bleeding

### DIFF
--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -261,9 +261,12 @@ const initialTheme = cookieTheme ?? 'light';
         morph animation and the per-path scroll restore with it. */}
 
     <style>
-      /* Sticky header with a tasteful backdrop blur on scroll — no solid
-         rule across the page. The horizontal line is implied by a tight
-         wordmark on the left and the icon trio on the right. */
+      /* Sticky header. Originally a frosted-glass effect (88% bg +
+         backdrop-blur) but the translucency let scrolled article body
+         text leak visibly through the header on detail-back navigation
+         even after the view-transition completed. Solid bg eliminates
+         the bleed; the wordmark + icon-trio composition still reads
+         clearly against the page without needing a frosted layer. */
       .site-header {
         position: sticky;
         top: 0;
@@ -273,28 +276,18 @@ const initialTheme = cookieTheme ?? 'light';
         justify-content: space-between;
         gap: 16px;
         padding: 14px 20px;
-        background-color: color-mix(in oklab, var(--bg) 88%, transparent);
-        backdrop-filter: saturate(160%) blur(12px);
-        -webkit-backdrop-filter: saturate(160%) blur(12px);
+        background-color: var(--bg);
         /* Issue #93 — give the header its own view-transition group so
            it morphs independently from the page-body root snapshot.
            Without this, the body's old→new morph plays underneath the
-           translucent header and content bleeds through, producing the
-           "flicker behind newsdigest header" the user reported. With
-           the named transition the browser captures the header as a
-           stable layer on top of the body morph. */
+           header and content bleeds through during the cross-fade. */
         view-transition-name: site-header;
       }
-      /* Issue #93 follow-up — the named view-transition group is not
-         enough on its own. The browser captures the header's PAINTED
-         pixels at snapshot time, which includes the backdrop-blur of
-         whatever content was beneath the header in the old vs new
-         pages. Cross-fading those two snapshots produces a visible
-         "swim" of the underlying article text through the header.
-         While a transition is active, force the header fully opaque
-         and disable the blur so old/new snapshots are pixel-identical
-         apart from the chrome (wordmark + nav buttons). The flag is
-         toggled by astro:before-preparation / astro:after-swap. */
+      /* Belt-and-braces: the during-transition rule survives because
+         the named view-transition group can briefly desync from the
+         body snapshot on slow devices. Keeping the explicit opaque
+         override here means even if a future refactor reintroduces a
+         translucent base, the in-flight transition stays solid. */
       [data-vt-active] .site-header {
         background-color: var(--bg);
         backdrop-filter: none;

--- a/tests/layouts/base.test.ts
+++ b/tests/layouts/base.test.ts
@@ -91,19 +91,34 @@ describe('Base.astro / page-effects.ts — view-transition wiring (REQ-DES-003 /
     // looked tasteful but was the source of the bleed in steady
     // state. Pin solid `var(--bg)` on the base rule so a regression
     // that re-introduces transparency is caught immediately.
-    const headerRule = baseSource.match(/\.site-header\s*\{[\s\S]*?\}/);
+    //
+    // The block extraction is anchored on the indentation Astro emits
+    // for the layout's <style> children (6 leading spaces, then '}'
+    // alone on a line). The earlier non-greedy form silently captured
+    // the wrong closing brace when nested at-rules were present.
+    const headerRule = baseSource.match(
+      /\n      \.site-header\s*\{([\s\S]*?)\n      \}/,
+    );
     expect(headerRule, 'expected a .site-header rule in Base.astro').not.toBeNull();
-    const block = headerRule?.[0] ?? '';
+    const block = headerRule?.[1] ?? '';
     expect(block).toMatch(/background-color:\s*var\(--bg\)\s*;/);
-    // Translucent backgrounds (color-mix with transparent, rgba alpha
-    // < 1, hsla alpha < 1) all produce the bleed and must stay out.
-    expect(block).not.toMatch(/color-mix\([^)]*transparent/);
-    expect(block).not.toMatch(/rgba?\([^)]*,\s*0?\.[0-9]+\s*\)/);
-    expect(block).not.toMatch(/hsla?\([^)]*,\s*0?\.[0-9]+%?\s*\)/);
+    // Translucent backgrounds (color-mix with transparent, rgba/hsla
+    // with alpha < 1 in either comma- or slash-separated form,
+    // decimal or percentage) all produce the bleed and must stay out.
+    // The previous `[^)]*transparent` form silently passed against
+    // the just-removed `color-mix(in oklab, var(--bg) 88%, transparent)`
+    // because `[^)]*` halted at the inner `)` of `var(--bg)` before
+    // reaching `transparent`. Use a non-anchored substring match.
+    expect(block).not.toMatch(/color-mix\b[\s\S]*?\btransparent\b[\s\S]*?\)/);
+    expect(block).not.toMatch(
+      /\b(?:rgba?|hsla?)\([^;]*(?:,\s*0?\.[0-9]+|\/\s*0?\.[0-9]+|\/\s*[0-9]{1,2}\s*%)\s*\)/,
+    );
     // backdrop-filter on an opaque bg has no visible effect; its
     // presence is a code smell that the bg was meant to be
-    // translucent. Reject it on the base rule.
-    expect(block).not.toMatch(/backdrop-filter:/);
+    // translucent. Reject both the standard and the -webkit-prefixed
+    // form on the base rule so a partial revert can't slip through
+    // on iOS Safari.
+    expect(block).not.toMatch(/(?:^|\s|;)(?:-webkit-)?backdrop-filter:/);
   });
 
   it('synchronously restores scroll on astro:after-swap so view-transition snapshots include below-fold cards', () => {

--- a/tests/layouts/base.test.ts
+++ b/tests/layouts/base.test.ts
@@ -84,6 +84,28 @@ describe('Base.astro / page-effects.ts — view-transition wiring (REQ-DES-003 /
     );
   });
 
+  it('site-header base style is fully opaque — no translucent bleed of scrolled content', () => {
+    // The user reported scrolled article body text bleeding through
+    // the header on detail-back nav even AFTER the view transition
+    // settled. The previous frosted-glass base (88% + backdrop-blur)
+    // looked tasteful but was the source of the bleed in steady
+    // state. Pin solid `var(--bg)` on the base rule so a regression
+    // that re-introduces transparency is caught immediately.
+    const headerRule = baseSource.match(/\.site-header\s*\{[\s\S]*?\}/);
+    expect(headerRule, 'expected a .site-header rule in Base.astro').not.toBeNull();
+    const block = headerRule?.[0] ?? '';
+    expect(block).toMatch(/background-color:\s*var\(--bg\)\s*;/);
+    // Translucent backgrounds (color-mix with transparent, rgba alpha
+    // < 1, hsla alpha < 1) all produce the bleed and must stay out.
+    expect(block).not.toMatch(/color-mix\([^)]*transparent/);
+    expect(block).not.toMatch(/rgba?\([^)]*,\s*0?\.[0-9]+\s*\)/);
+    expect(block).not.toMatch(/hsla?\([^)]*,\s*0?\.[0-9]+%?\s*\)/);
+    // backdrop-filter on an opaque bg has no visible effect; its
+    // presence is a code smell that the bg was meant to be
+    // translucent. Reject it on the base rule.
+    expect(block).not.toMatch(/backdrop-filter:/);
+  });
+
   it('synchronously restores scroll on astro:after-swap so view-transition snapshots include below-fold cards', () => {
     // Without an in-callback scroll restore, the View-Transition
     // snapshot of the new page is captured at scrollY=0. Any card


### PR DESCRIPTION
## Summary
- Replace translucent header bg (88% + backdrop-blur) with solid `var(--bg)`.
- Scrolled article body text no longer leaks visibly through the header on detail-back nav.
- Keep `[data-vt-active]` override as belt-and-braces for the in-transition window.
- Drop `backdrop-filter` from the base rule (no visible effect over an opaque bg).
- Add regression test rejecting transparent variants of the rule.

## Why
User reported the bleed twice. The previous fix (data-vt-active flag) only addressed the during-transition flicker — the steady-state translucency continued to show scrolled content underneath the sticky header.

## REQs touched
- REQ-DES-003 (view transitions / sticky header)

## Test plan
- [ ] CI green
- [ ] After deploy: open /digest, scroll down, click any card to read the article, click back. Header is fully opaque; no body text visible underneath at any scroll position.