### PR TITLE
HOTFIX: restore 'unsafe-inline' to style-src — production down

### DIFF
--- a/sdd/observability.md
+++ b/sdd/observability.md
@@ -51,7 +51,7 @@ Structured JSON logging as the single operational surface — no external observ
 **Applies To:** User
 
 **Acceptance Criteria:**
-1. Every response includes `Content-Security-Policy: default-src 'self'; script-src 'self'; style-src 'self'; img-src 'self' data: https:; connect-src 'self'; font-src 'self' data:; frame-ancestors 'none'; base-uri 'self'; form-action 'self' https://github.com`.
+1. Every response includes `Content-Security-Policy: default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; connect-src 'self'; font-src 'self' data:; frame-ancestors 'none'; base-uri 'self'; form-action 'self' https://github.com`. The `'unsafe-inline'` allowance on `style-src` is required because Astro emits component-scoped styles as inline `<style>` blocks; `script-src` remains strict.
 2. Every response includes `Strict-Transport-Security: max-age=63072000; includeSubDomains; preload`.
 3. Every response includes `X-Content-Type-Options: nosniff` and `Referrer-Policy: strict-origin-when-cross-origin`.
 4. Every response includes `Permissions-Policy: geolocation=(), microphone=(), camera=(), payment=(), clipboard-read=()`.

--- a/src/middleware/security-headers.ts
+++ b/src/middleware/security-headers.ts
@@ -29,17 +29,18 @@
 /** Exact Content-Security-Policy value required by REQ-OPS-003 AC 1.
  * Pinned byte-for-byte in tests — do not reformat or reorder directives.
  *
- * `style-src 'self'` (no `'unsafe-inline'`): every `<style>` block in
- * the codebase is scoped or `is:global` — Astro extracts both kinds to
- * external `.css` files at build time, served from the same origin
- * and satisfying `'self'`. There are no `<style is:inline>` blocks and
- * no `style="..."` attributes anywhere in `src/`. Dynamic style work
- * (FLIP transforms, view-transition-name assignments) uses the DOM
- * API (`el.style.X = ...`, `setProperty`), which CSP `style-src` does
- * NOT block — that policy targets inline `<style>` content and `style=`
- * attributes only. */
+ * `style-src 'self' 'unsafe-inline'`: Astro emits component-scoped CSS
+ * (the `data-astro-cid-*` mechanism) as inline `<style>` blocks at the
+ * end of the head, NOT as external `.css` files. The first deploy of
+ * `style-src 'self'` (no `'unsafe-inline'`) broke every page in
+ * production: scoped styles for the landing page, the digest grid, the
+ * tag railing, and every component-scoped animation were blocked. The
+ * `'unsafe-inline'` allowance is the only viable policy until Astro
+ * supports per-block nonce attribution for compiled scoped styles
+ * (tracked upstream — no current workaround). `script-src 'self'`
+ * remains strict. */
 export const CSP_HEADER_VALUE =
-  "default-src 'self'; script-src 'self'; style-src 'self'; img-src 'self' data: https:; connect-src 'self'; font-src 'self' data:; frame-ancestors 'none'; base-uri 'self'; form-action 'self' https://github.com";
+  "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; connect-src 'self'; font-src 'self' data:; frame-ancestors 'none'; base-uri 'self'; form-action 'self' https://github.com";
 
 /** HSTS value required by REQ-OPS-003 AC 2 — two-year max-age, subdomains,
  * and opt-in to the HSTS preload list. */

--- a/tests/observability/security-headers.test.ts
+++ b/tests/observability/security-headers.test.ts
@@ -33,7 +33,7 @@ describe('security-headers middleware', () => {
   describe('constants', () => {
     it('REQ-OPS-003: CSP matches the spec byte-for-byte', () => {
       expect(CSP_HEADER_VALUE).toBe(
-        "default-src 'self'; script-src 'self'; style-src 'self'; img-src 'self' data: https:; connect-src 'self'; font-src 'self' data:; frame-ancestors 'none'; base-uri 'self'; form-action 'self' https://github.com",
+        "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; connect-src 'self'; font-src 'self' data:; frame-ancestors 'none'; base-uri 'self'; form-action 'self' https://github.com",
       );
     });
 


### PR DESCRIPTION
Production hotfix.

**What broke:** CSP tightening landed in PR1 (#162) with `style-src 'self'` (no `'unsafe-inline'`). The original analysis claimed Astro extracts all `<style>` blocks to external CSS at build time. **That is wrong.** Astro emits component-scoped styles (the `data-astro-cid-*` mechanism) as inline `<style>` blocks at the end of the `<head>`, NOT as external CSS files. The strict CSP blocked them in production.

**Symptoms reported:** login screen CSS not loading, tag railing broken everywhere, all animations broken.

**Verified live HTML on news.graymatter.ch shows:**
`<style>.landing[data-astro-cid-j7pv25f6]{...}</style>` immediately after the external CSS link — exactly what CSP `style-src 'self'` rejects.

**Fix:** restore `'unsafe-inline'` to `style-src`. `script-src 'self'` remains strict. Also updates the byte-pin test and the spec REQ-OPS-003 AC 1.

**Future:** per-block nonce attribution for Astro's compiled scoped styles is the proper fix; tracked upstream, no current workaround.