### PR TITLE
review-2026-05-03 PR3: coordinator hygiene cluster (12 fixes)

### DIFF
--- a/src/lib/discovery.ts
+++ b/src/lib/discovery.ts
@@ -24,7 +24,7 @@
 // REQ-DISC-004 can surface a Re-discover button on the settings page.
 
 import { XMLParser } from 'fast-xml-parser';
-import { DISCOVERY_SYSTEM, discoveryUserPrompt, LLM_PARAMS } from '~/lib/prompts';
+import { DISCOVERY_SYSTEM, discoveryUserPrompt, DISCOVERY_LLM_PARAMS } from '~/lib/prompts';
 import { FALLBACK_MODEL_ID } from '~/lib/models';
 import { runJsonWithFallback } from '~/lib/llm-json';
 import { isUrlSafe } from '~/lib/ssrf';
@@ -95,7 +95,7 @@ export async function discoverTag(tag: string, env: Env): Promise<DiscoveredFeed
         { role: 'system', content: DISCOVERY_SYSTEM },
         { role: 'user', content: userPrompt },
       ],
-      ...LLM_PARAMS,
+      ...DISCOVERY_LLM_PARAMS,
     },
     narrow: (raw) => narrowDiscoveryPayload(raw),
     onPrimaryFailure: (info) => {

--- a/src/lib/hashtags.ts
+++ b/src/lib/hashtags.ts
@@ -6,9 +6,31 @@
 // `parseJsonStringArray` helper — kept as its own export so calling
 // sites read at the domain ("parse this user's hashtags") rather than
 // at the implementation level ("parse a JSON string array").
+//
+// Also home of the canonical {@link normalizeHashtag} helper, which
+// CF-034 consolidated from inline repetitions across settings.ts,
+// scrape-chunk-consumer.ts, and the four UI/admin sites that built
+// their own ad-hoc lowercase + #-strip + filter chains. New code
+// MUST import from here.
 
 import { parseJsonStringArray } from './json-string-array';
 
 export function parseHashtags(hashtagsJson: string | null): string[] {
   return parseJsonStringArray(hashtagsJson);
 }
+
+/**
+ * Canonical normaliser for a single hashtag string. Strips a leading
+ * `#`, lowercases, and drops every character outside `[a-z0-9-]`.
+ * The result is NOT length-checked here — callers validate with
+ * {@link HASHTAG_REGEX} after collecting the full list so error
+ * messages can reference the original input.
+ */
+export function normalizeHashtag(raw: string): string {
+  const lowered = raw.toLowerCase();
+  const unHashed = lowered.startsWith('#') ? lowered.slice(1) : lowered;
+  return unHashed.replace(/[^a-z0-9-]/g, '');
+}
+
+/** Tag-shape contract: 2..32 chars, lowercase letters/digits/dashes. */
+export const HASHTAG_REGEX = /^[a-z0-9-]{2,32}$/;

--- a/src/lib/oauth-errors.ts
+++ b/src/lib/oauth-errors.ts
@@ -45,10 +45,11 @@ export function mapOAuthError(raw: string | null | undefined): OAuthErrorCode {
 }
 
 /**
- * True iff {@link code} is a member of the public allowlist. Callers
- * should prefer {@link mapOAuthError} — this exists for parsing
- * untrusted query strings (e.g., landing-page rendering) where we only
- * want to render a message for a value we produced ourselves.
+ * @internal — exported for the OAuth-error-code unit test only. Production
+ * callers MUST use {@link mapOAuthError}, which delivers the structured
+ * `{ message, severity }` shape; this predicate's existence is purely so
+ * the test surface can verify membership without re-typing the allowlist
+ * literal.
  */
 export function isKnownOAuthErrorCode(code: unknown): code is OAuthErrorCode {
   return typeof code === 'string' && (OAUTH_ERROR_CODES as readonly string[]).includes(code);

--- a/src/lib/prompts.ts
+++ b/src/lib/prompts.ts
@@ -16,22 +16,48 @@
 // across calls so outputs remain reproducible.
 
 /**
- * Shared inference parameters for every Workers AI call.
+ * Shared inference parameters across the chunk + finalize Workers AI
+ * calls. Temperature and response_format are identical; only
+ * max_tokens varies (CF-023). `LLM_PARAMS` remains exported as the
+ * chunk-sized variant for backwards compatibility with any importer
+ * that pulled the original constant.
+ *
  * - `temperature: 0.6` — warm enough for the model to pick longer
  *   completions over minimum-entropy short replies, cool enough for
  *   stable JSON output. 0.7 was working but 0.6 trims variance on
  *   the shorter 150-200 word target.
- * - `max_tokens: 50000` — budget for ~50 articles per chunk at
- *   150-200 words each (~280 toks/article → ~14K total with JSON
- *   overhead). Input side is ~8K tokens for the prompt +
- *   candidate list.
  * - `response_format` — force JSON output on models that support it.
  */
-export const LLM_PARAMS = {
+const LLM_BASE_PARAMS = {
   temperature: 0.6,
-  max_tokens: 50_000,
   response_format: { type: 'json_object' },
 } as const;
+
+/**
+ * Chunk-prompt budget — ~50 articles × 150-200 words each
+ * (~280 toks/article → ~14K total with JSON overhead). Input side is
+ * ~8K tokens for the prompt + candidate list.
+ */
+export const CHUNK_LLM_PARAMS = {
+  ...LLM_BASE_PARAMS,
+  max_tokens: 50_000,
+} as const;
+
+/**
+ * Finalize-prompt budget — output is just a `dedup_groups: number[][]`
+ * payload, typically <100 tokens. The 50K cap inherited from the
+ * shared variant was wasteful in both reservation and observability.
+ * 4K leaves comfortable headroom for an over-eager LLM without
+ * misrepresenting the call's actual token footprint.
+ */
+export const FINALIZE_LLM_PARAMS = {
+  ...LLM_BASE_PARAMS,
+  max_tokens: 4_000,
+} as const;
+
+/** Backwards-compatible alias. New code should import the variant
+ *  that matches the call site (chunk vs finalize) directly. */
+export const LLM_PARAMS = CHUNK_LLM_PARAMS;
 
 // Implements REQ-PIPE-002
 //

--- a/src/lib/prompts.ts
+++ b/src/lib/prompts.ts
@@ -16,11 +16,10 @@
 // across calls so outputs remain reproducible.
 
 /**
- * Shared inference parameters across the chunk + finalize Workers AI
- * calls. Temperature and response_format are identical; only
- * max_tokens varies (CF-023). `LLM_PARAMS` remains exported as the
- * chunk-sized variant for backwards compatibility with any importer
- * that pulled the original constant.
+ * Shared inference parameters across the LLM calls. Temperature and
+ * response_format are identical; only `max_tokens` varies per call
+ * site (CF-023): chunk processing produces large multi-article
+ * payloads, while finalize and discovery produce tiny JSON envelopes.
  *
  * - `temperature: 0.6` — warm enough for the model to pick longer
  *   completions over minimum-entropy short replies, cool enough for
@@ -55,9 +54,15 @@ export const FINALIZE_LLM_PARAMS = {
   max_tokens: 4_000,
 } as const;
 
-/** Backwards-compatible alias. New code should import the variant
- *  that matches the call site (chunk vs finalize) directly. */
-export const LLM_PARAMS = CHUNK_LLM_PARAMS;
+/**
+ * Discovery-prompt budget — output is `{ feeds: [{ url, name, kind }] }`,
+ * usually a handful of entries. Same 4K cap as finalize: small JSON
+ * envelope, no benefit from the chunk-sized 50K reservation.
+ */
+export const DISCOVERY_LLM_PARAMS = {
+  ...LLM_BASE_PARAMS,
+  max_tokens: 4_000,
+} as const;
 
 // Implements REQ-PIPE-002
 //

--- a/src/lib/sources.ts
+++ b/src/lib/sources.ts
@@ -176,7 +176,11 @@ const REDDIT: SourceAdapter = {
   },
 };
 
-/** The three generic sources fanned out for every hashtag. */
+/** The three generic sources fanned out for every hashtag.
+ * @internal — used by tests only since the global-feed rework
+ * (2026-04-23) replaced per-tag fan-out with curated registry +
+ * discovered-tag KV entries. Kept exported for the test fixture
+ * suite (tests/sources/published-at.test.ts, tests/lib/prefer-direct-source.test.ts). */
 export const GENERIC_SOURCES: SourceAdapter[] = [HACKER_NEWS, GOOGLE_NEWS, REDDIT];
 
 // ---------- Fetch one source for one tag ---------------------------------
@@ -294,14 +298,18 @@ export async function fetchFromSourceWithResult(
 // ---------- Fan-out ------------------------------------------------------
 
 /**
- * Fan out across every {tag × source} combination, respecting a global
- * concurrency cap of 10. `discoveredByTag` provides tag-specific feeds
- * discovered earlier (see `sources:{tag}` in KV) — those headlines are
- * preferred over generic sources when deduplication drops later
- * occurrences of a canonical URL, and they also come first in the
- * returned array so upstream 100-cap truncation keeps them.
+ * @internal — used by tests only since the global-feed rework
+ * (2026-04-23) replaced per-tag fan-out with the curated registry +
+ * discovered-tag KV cache that scrape-coordinator now drives via
+ * `fetchAllSources` / `fetchFromSourceWithResult`. Kept exported for
+ * the test fixture suite. Production no longer routes through this
+ * function.
  *
- * Returned headlines are deduplicated by canonical URL
+ * Original fan-out semantics: every {tag × source} combination,
+ * respecting a global concurrency cap of 10. `discoveredByTag`
+ * provides tag-specific feeds discovered earlier (see `sources:{tag}`
+ * in KV); discovered feeds come first so upstream 100-cap truncation
+ * keeps them. Returned headlines are deduplicated by canonical URL
  * and truncated to {@link MAX_COMBINED_HEADLINES}.
  */
 export async function fanOutForTags(
@@ -398,10 +406,16 @@ export async function fanOutForTags(
  */
 export function adaptersForDiscoveredFeeds(
   feeds: DiscoveredFeed[],
+  options: { trusted?: boolean } = {},
 ): SourceAdapter[] {
   const adapters: SourceAdapter[] = [];
+  const trusted = options.trusted === true;
   for (const feed of feeds) {
-    if (!isUrlSafe(feed.url)) {
+    // CF-025 — curated adapters call this with `trusted: true` because
+    // the curated registry is HTTPS-by-invariant; running ~70 SSRF
+    // gates per coordinator tick on URLs we hard-coded ourselves is
+    // pure waste. Discovered feeds (LLM-suggested) keep the gate.
+    if (!trusted && !isUrlSafe(feed.url)) {
       log('warn', 'source.fetch.failed', {
         source: feed.name,
         reason: 'ssrf',
@@ -410,7 +424,11 @@ export function adaptersForDiscoveredFeeds(
       continue;
     }
     const feedUrl = feed.url;
-    const sourceName = `feed:${feed.name}`;
+    // CF-021 — drop the `feed:` prefix for consistency with curated
+    // adapters. Dashboards aggregating by `source` field previously
+    // had a hidden split between curated (`Foo Bar`) and discovered
+    // (`feed:Foo Bar`); both now use the bare name.
+    const sourceName = feed.name;
     adapters.push({
       name: sourceName,
       kind: feed.kind,

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -20,12 +20,11 @@ export interface Headline {
   url: string;
   snippet?: string;
   source_name: string;
-  /** User hashtags that produced this headline during fan-out. A single
-   * canonical URL can match multiple tags (e.g. a Cloudflare blog post
-   * that's relevant to both #cloudflare and #ai); dedupe unions the
-   * tags so downstream the LLM sees every matching topic for the item.
-   * Populated by fanOutForTags; extract() implementations don't need
-   * to set it. */
+  /** Tags relevant to this headline. Populated by the coordinator via
+   * the discovered-tag KV cache (`sources:{tag}` reverse-indexed) and
+   * by curated-source registry entries; the LLM sees every matching
+   * topic for the item. Extract() implementations don't need to set
+   * it — the coordinator stamps the field after fetch. */
   source_tags?: string[];
   /** Unix-seconds publication timestamp parsed from the feed entry
    * (RSS `<pubDate>`, Atom `<published>`/`<updated>`, JSON Feed

--- a/src/middleware/auth.ts
+++ b/src/middleware/auth.ts
@@ -21,7 +21,7 @@
 // the UA cannot legitimately drift across two parallel requests.
 
 import { signSession, verifySession } from '~/lib/session-jwt';
-import { readCookie as readCookieCanonical } from '~/lib/crypto';
+import { readCookie } from '~/lib/crypto';
 import {
   REFRESH_TOKEN_COOKIE_NAME,
   ROTATION_GRACE_SECONDS,
@@ -63,16 +63,6 @@ interface UserRow {
   email_enabled: number;
   session_version: number;
 }
-
-/**
- * Parse a single cookie value out of a Cookie header string. Returns
- * null when the cookie is absent. Case-sensitive per RFC 6265.
- *
- * Re-exported from `~/lib/crypto` (CF-005). New code should import the
- * canonical version directly; this re-export preserves callers that
- * already imported `readCookie` from this module.
- */
-export const readCookie = readCookieCanonical;
 
 /**
  * Build the `Set-Cookie` string for a signed session JWT.

--- a/src/pages/api/settings.ts
+++ b/src/pages/api/settings.ts
@@ -40,12 +40,11 @@ import { isValidTz } from '~/lib/tz';
 import { requireSession } from '~/middleware/auth';
 import { checkOrigin, originOf } from '~/middleware/origin-check';
 
-/**
- * Regex enforcing the hashtag character set and length. Matches the
- * spec AC literally — 2..32 chars, lowercase letters, digits, or hyphen.
- * Anchored so a partial match does not satisfy the check.
- */
-export const HASHTAG_REGEX = /^[a-z0-9-]{2,32}$/;
+// Re-exported from `~/lib/hashtags` (CF-034 consolidation). Existing
+// importers that pulled `HASHTAG_REGEX` / `normalizeHashtag` from this
+// module keep working; new code SHOULD import from the lib directly.
+import { HASHTAG_REGEX as HASHTAG_REGEX_LIB, normalizeHashtag as normalizeHashtagLib } from '~/lib/hashtags';
+export const HASHTAG_REGEX = HASHTAG_REGEX_LIB;
 
 /** Maximum hashtags per user (REQ-SET-002 AC 6).
  *  Sized to give new accounts headroom above the default seed; the
@@ -74,22 +73,7 @@ interface UserSettingsRow {
 }
 
 
-/**
- * Normalize a single user-typed hashtag:
- *   1. strip a leading `#`
- *   2. lowercase
- *   3. drop every character not in [a-z0-9-]
- * The result is not checked against the 2..32 length bounds here —
- * callers validate that with {@link HASHTAG_REGEX} after collecting the
- * full list, so error messages can reference the original input.
- */
-export function normalizeHashtag(raw: string): string {
-  const lowered = raw.toLowerCase();
-  const unHashed = lowered.startsWith('#') ? lowered.slice(1) : lowered;
-  // Replace anything outside the allowed set with empty string. Using a
-  // regex avoids a per-char loop on the hot path.
-  return unHashed.replace(/[^a-z0-9-]/g, '');
-}
+export const normalizeHashtag = normalizeHashtagLib;
 
 /**
  * Validate and normalize the hashtags payload. Returns either a cleaned

--- a/src/pages/api/settings.ts
+++ b/src/pages/api/settings.ts
@@ -40,11 +40,7 @@ import { isValidTz } from '~/lib/tz';
 import { requireSession } from '~/middleware/auth';
 import { checkOrigin, originOf } from '~/middleware/origin-check';
 
-// Re-exported from `~/lib/hashtags` (CF-034 consolidation). Existing
-// importers that pulled `HASHTAG_REGEX` / `normalizeHashtag` from this
-// module keep working; new code SHOULD import from the lib directly.
-import { HASHTAG_REGEX as HASHTAG_REGEX_LIB, normalizeHashtag as normalizeHashtagLib } from '~/lib/hashtags';
-export const HASHTAG_REGEX = HASHTAG_REGEX_LIB;
+import { HASHTAG_REGEX, normalizeHashtag } from '~/lib/hashtags';
 
 /** Maximum hashtags per user (REQ-SET-002 AC 6).
  *  Sized to give new accounts headroom above the default seed; the
@@ -72,8 +68,6 @@ interface UserSettingsRow {
   email_enabled: number;
 }
 
-
-export const normalizeHashtag = normalizeHashtagLib;
 
 /**
  * Validate and normalize the hashtags payload. Returns either a cleaned

--- a/src/queue/cleanup.ts
+++ b/src/queue/cleanup.ts
@@ -79,9 +79,14 @@ export async function runCleanup(env: Env): Promise<{
 }
 
 /** CF-008 — delete `scrape_chunk_completions` rows for runs whose
- *  `finished_at` is older than the 14-day retention window. Bounded
- *  growth: at ~22k rows/year/deployment without this sweep, the table
- *  becomes the leaking source migration 0007 explicitly called out. */
+ *  `finished_at` is older than the 14-day retention window OR whose
+ *  parent `scrape_runs` row is missing entirely (orphan rows from
+ *  finalize crashes / manual aborts). Bounded growth: at ~22k
+ *  rows/year/deployment without this sweep, the table becomes the
+ *  leaking source migration 0007 explicitly called out. The two
+ *  predicates run in one statement so the cron stays a single round-
+ *  trip; finished_at IS NULL on an in-flight run is preserved by the
+ *  EXISTS check. */
 async function runChunkCompletionsPurge(env: Env): Promise<number> {
   const cutoff = Math.floor(Date.now() / 1000) - RETENTION_SECONDS;
   try {
@@ -89,8 +94,12 @@ async function runChunkCompletionsPurge(env: Env): Promise<number> {
       .prepare(
         `DELETE FROM scrape_chunk_completions
           WHERE scrape_run_id IN (
-            SELECT id FROM scrape_runs WHERE finished_at < ?1
-          )`,
+                  SELECT id FROM scrape_runs WHERE finished_at < ?1
+                )
+             OR NOT EXISTS (
+                  SELECT 1 FROM scrape_runs
+                   WHERE id = scrape_chunk_completions.scrape_run_id
+                )`,
       )
       .bind(cutoff)
       .run();

--- a/src/queue/cleanup.ts
+++ b/src/queue/cleanup.ts
@@ -59,6 +59,7 @@ export async function runCleanup(env: Env): Promise<{
   orphanTagsDeleted: number;
   stuckTagsPruned: number;
   refreshTokensPurged: number;
+  chunkCompletionsPurged: number;
 }> {
   const articlesDeleted = await runArticleRetention(env);
   // Stuck-tag prune runs BEFORE the orphan sweep so the same run
@@ -67,7 +68,46 @@ export async function runCleanup(env: Env): Promise<{
   const stuckTagsPruned = await runStuckTagPrune(env);
   const orphanTagsDeleted = await runOrphanTagSweep(env);
   const refreshTokensPurged = await runRefreshTokenPurge(env);
-  return { articlesDeleted, orphanTagsDeleted, stuckTagsPruned, refreshTokensPurged };
+  const chunkCompletionsPurged = await runChunkCompletionsPurge(env);
+  return {
+    articlesDeleted,
+    orphanTagsDeleted,
+    stuckTagsPruned,
+    refreshTokensPurged,
+    chunkCompletionsPurged,
+  };
+}
+
+/** CF-008 — delete `scrape_chunk_completions` rows for runs whose
+ *  `finished_at` is older than the 14-day retention window. Bounded
+ *  growth: at ~22k rows/year/deployment without this sweep, the table
+ *  becomes the leaking source migration 0007 explicitly called out. */
+async function runChunkCompletionsPurge(env: Env): Promise<number> {
+  const cutoff = Math.floor(Date.now() / 1000) - RETENTION_SECONDS;
+  try {
+    const result = await env.DB
+      .prepare(
+        `DELETE FROM scrape_chunk_completions
+          WHERE scrape_run_id IN (
+            SELECT id FROM scrape_runs WHERE finished_at < ?1
+          )`,
+      )
+      .bind(cutoff)
+      .run();
+    const purged = result.meta?.changes ?? 0;
+    log('info', 'digest.generation', {
+      status: 'cleanup_chunk_completions_purged',
+      purged,
+      cutoff_unix: cutoff,
+    });
+    return purged;
+  } catch (err) {
+    log('error', 'digest.generation', {
+      status: 'cleanup_chunk_completions_failed',
+      detail: String(err).slice(0, 500),
+    });
+    return 0;
+  }
 }
 
 /** REQ-AUTH-008 — drop expired refresh-token rows + revoked rows older

--- a/src/queue/scrape-chunk-consumer.ts
+++ b/src/queue/scrape-chunk-consumer.ts
@@ -46,6 +46,7 @@ import {
 } from '~/lib/dedupe';
 import { fetchArticleBodies } from '~/lib/article-fetch';
 import { DEFAULT_HASHTAGS } from '~/lib/default-hashtags';
+import { normalizeHashtag } from '~/lib/hashtags';
 import { splitIntoParagraphs } from '~/lib/paragraph-split';
 import { FALLBACK_MODEL_ID } from '~/lib/models';
 import { runJsonWithFallback, previewRawResponse } from '~/lib/llm-json';
@@ -418,7 +419,10 @@ export async function processOneChunk(
     const seen = new Set<string>();
     for (const t of llmTags) {
       if (typeof t !== 'string') continue;
-      const normalised = t.trim().toLowerCase().replace(/^#/, '');
+      // CF-034 — same normalisation the user-settings write-path applies,
+      // so an LLM-emitted "Cloud Infrastructure" lands as the same canonical
+      // form a user typed "#cloud-infrastructure" into settings.
+      const normalised = normalizeHashtag(t.trim());
       if (normalised === '' || seen.has(normalised)) continue;
       if (!allowedTagSet.has(normalised)) continue;
       seen.add(normalised);

--- a/src/queue/scrape-chunk-consumer.ts
+++ b/src/queue/scrape-chunk-consumer.ts
@@ -31,7 +31,7 @@
 
 import {
   PROCESS_CHUNK_SYSTEM,
-  LLM_PARAMS,
+  CHUNK_LLM_PARAMS,
   processChunkUserPrompt,
 } from '~/lib/prompts';
 import {
@@ -220,7 +220,7 @@ export async function processOneChunk(
         { role: 'system', content: PROCESS_CHUNK_SYSTEM },
         { role: 'user', content: processChunkUserPrompt(promptCandidates, allowedTags) },
       ],
-      ...LLM_PARAMS,
+      ...CHUNK_LLM_PARAMS,
     },
     narrow: (raw) => narrowChunkPayload(parseLLMPayload(raw), raw),
     onPrimaryFailure: (info) => {

--- a/src/queue/scrape-chunk-consumer.ts
+++ b/src/queue/scrape-chunk-consumer.ts
@@ -291,8 +291,6 @@ export async function processOneChunk(
   // Map merged clusters back to their LLM article payloads. A merged
   // cluster at anchor index N uses articles[N] for title/details/tags;
   // the other grouped indices are collapsed into article_sources rows.
-  // Track which input indices made it into which merged cluster.
-  const collapsedSet = buildCollapsedSet(perInputClusters.length, dedupGroups);
 
   interface Survivor {
     cluster: Cluster;
@@ -635,9 +633,6 @@ export async function processOneChunk(
     dropped_for_title_mismatch: droppedForTitleMismatch,
   });
 
-  // Suppress unused-variable warning for collapsedSet; kept for future
-  // per-alternative source attribution refinements.
-  void collapsedSet;
 }
 
 // titlesShareAnyToken / tokenizeTitle moved to ~/lib/title-overlap (CF-058).
@@ -737,21 +732,3 @@ function buildAnchorIndices(
   return anchors;
 }
 
-/** Track which input indices were collapsed into a merged cluster so
- * their candidate rows land in `article_sources` rather than creating
- * a new `articles` row. Returned for future per-alternative source
- * attribution; currently referenced via `void` to silence the linter. */
-function buildCollapsedSet(
-  inputCount: number,
-  dedupGroups: number[][],
-): Set<number> {
-  const collapsed = new Set<number>();
-  for (const group of dedupGroups) {
-    const valid = group
-      .filter((i) => Number.isInteger(i) && i >= 0 && i < inputCount)
-      .sort((a, b) => a - b);
-    if (valid.length < 2) continue;
-    for (const i of valid.slice(1)) collapsed.add(i);
-  }
-  return collapsed;
-}

--- a/src/queue/scrape-coordinator.ts
+++ b/src/queue/scrape-coordinator.ts
@@ -79,6 +79,14 @@ const PER_SOURCE_ITEM_CAP = 10;
  * tag set without exploding LLM cost. */
 const MAX_CHUNKS_PER_TICK = 40;
 
+/** Freshness cutoff for keeping a candidate after the canonical-dedupe
+ * pass. Anything older than 48 hours is treated as stale and dropped
+ * unless the feed declined to provide a pubDate (those fall back to
+ * the coordinator's now-second so they always pass the cutoff and
+ * land with a usable timestamp). Promoted to module scope so the
+ * tunable lives next to the other coordinator constants. */
+const FRESHNESS_WINDOW_SEC = 48 * 60 * 60;
+
 /** CF-012 + CF-073: cap the chunk fan-out at `max` and emit a single
  *  `coordinator_chunks_capped` warning when truncation actually
  *  happens. Exported for direct testing — the production caller is
@@ -120,6 +128,22 @@ function isSafeWebUrl(url: string): boolean {
  * cron branch in `src/worker.ts`. */
 export interface CoordinatorMessage {
   scrape_run_id: string;
+}
+
+/** Shape of a single chunk candidate enqueued to the chunk consumer.
+ * Promoted to a named interface so the array typing reads naturally
+ * (`ChunkCandidate[][]` instead of `typeof chunkCandidates[]`). */
+export interface ChunkCandidate {
+  canonical_url: string;
+  source_url: string;
+  source_name: string;
+  title: string;
+  published_at: number;
+  body_snippet?: string;
+  alternatives: Array<{
+    source_url: string;
+    source_name: string;
+  }>;
 }
 
 /** Queue handler entry point. Delegates the per-message try/ack/retry/
@@ -234,7 +258,7 @@ export async function runCoordinator(
   // value in an href attribute is NOT enough — Astro's escaping
   // prevents HTML injection but a `javascript:` href is valid HTML).
   const candidates: Candidate[] = [];
-  const evictionNowSec = Math.floor(Date.now() / 1000);
+  const coordinatorNowSec = Math.floor(Date.now() / 1000);
   // Drop candidates whose source pubDate is more than 48 hours old.
   // Cron runs every 4 hours, so anything older than two days has
   // either been seen on a prior tick (and is already in the pool)
@@ -242,10 +266,9 @@ export async function runCoordinator(
   // summarising it wastes LLM budget and clutters the dashboard with
   // 'new ingest, old publish_at' cards that sort below genuinely
   // fresh stories and make the feed look stuck. candidates with an
-  // unparsable pubDate (we fall back to evictionNowSec) are kept — a
+  // unparsable pubDate (we fall back to coordinatorNowSec) are kept — a
   // missing date is not the same as a stale date.
-  const FRESHNESS_WINDOW_SEC = 48 * 60 * 60;
-  const staleCutoff = evictionNowSec - FRESHNESS_WINDOW_SEC;
+  const staleCutoff = coordinatorNowSec - FRESHNESS_WINDOW_SEC;
   let droppedStale = 0;
   let missingPubdateKept = 0;
   for (const row of rawHeadlines) {
@@ -254,7 +277,7 @@ export async function runCoordinator(
     if (!isSafeWebUrl(canonical)) continue;
     const hasParsedPub =
       typeof row.headline.published_at === 'number' && row.headline.published_at > 0;
-    const pub = hasParsedPub ? (row.headline.published_at as number) : evictionNowSec;
+    const pub = hasParsedPub ? (row.headline.published_at as number) : coordinatorNowSec;
     if (hasParsedPub && pub < staleCutoff) {
       droppedStale += 1;
       continue;
@@ -384,7 +407,7 @@ export async function runCoordinator(
   // budget and parallelises across chunks.
 
   // --- Step 7: Flatten clusters into chunk-ready candidates -----------
-  const chunkCandidates = survivors.map((c) => {
+  const chunkCandidates: ChunkCandidate[] = survivors.map((c) => {
     const existingSnippet = c.primary.body_snippet ?? '';
     return {
       canonical_url: c.primary.canonical_url,
@@ -401,7 +424,7 @@ export async function runCoordinator(
   });
 
   // --- Step 8: Chunk + prime KV counter + enqueue ---------------------
-  const chunks: typeof chunkCandidates[] = [];
+  const chunks: ChunkCandidate[][] = [];
   for (let i = 0; i < chunkCandidates.length; i += CHUNK_SIZE) {
     chunks.push(chunkCandidates.slice(i, i + CHUNK_SIZE));
   }
@@ -493,7 +516,7 @@ function curatedToAdapter(curated: CuratedSource): SourceAdapter {
     url: curated.feed_url,
     kind: curated.kind,
   };
-  const adapters = adaptersForDiscoveredFeeds([feed]);
+  const adapters = adaptersForDiscoveredFeeds([feed], { trusted: true });
   const first = adapters[0];
   if (first !== undefined) return first;
   // Shouldn't happen — if adaptersForDiscoveredFeeds rejects a curated
@@ -745,7 +768,9 @@ export async function applyEvictions(
       if (raw === null) {
         // Entry already cleared (likely via /api/admin/discovery/retry
         // between ticks); still clear the per-URL counter and move on.
-        for (const url of evictedUrls) await clearHealth(env, url);
+        for (const url of evictedUrls) {
+          try { await clearHealth(env, url); } catch { /* CF-017 — best-effort; a per-URL failure must not abort the eviction loop */ }
+        }
         continue;
       }
       let parsed: unknown;
@@ -772,6 +797,14 @@ export async function applyEvictions(
       // on any mismatch — health counters are already cleared above,
       // and the next scrape tick will re-evaluate health against the
       // new feed set.
+      //
+      // CF-017 — the byte-equal `latestRaw === raw` compare is
+      // correct ONLY because `JSON.stringify` is the sole writer of
+      // sources:{tag} entries (in this file at line 813 and in
+      // discovery.ts when persisting fresh feeds). If a future caller
+      // writes the entry with a different serialization (whitespace
+      // variation, key ordering), this race-recheck will false-
+      // positive and clobber legitimate concurrent writes.
       const latestRaw = await env.KV.get(`sources:${tag}`, 'text');
       if (latestRaw !== raw) {
         log('info', 'discovery.completed', {
@@ -779,7 +812,9 @@ export async function applyEvictions(
           scrape_run_id,
           tag,
         });
-        for (const url of evictedUrls) await clearHealth(env, url);
+        for (const url of evictedUrls) {
+          try { await clearHealth(env, url); } catch { /* CF-017 — best-effort; a per-URL failure must not abort the eviction loop */ }
+        }
         continue;
       }
 
@@ -791,7 +826,9 @@ export async function applyEvictions(
 
       // Clear the per-URL health counters so a re-discovered URL at
       // the same address starts from a clean slate.
-      for (const url of evictedUrls) await clearHealth(env, url);
+      for (const url of evictedUrls) {
+          try { await clearHealth(env, url); } catch { /* CF-017 — best-effort; a per-URL failure must not abort the eviction loop */ }
+        }
 
       log('warn', 'discovery.completed', {
         status: 'feed_evicted',

--- a/src/queue/scrape-coordinator.ts
+++ b/src/queue/scrape-coordinator.ts
@@ -769,7 +769,17 @@ export async function applyEvictions(
         // Entry already cleared (likely via /api/admin/discovery/retry
         // between ticks); still clear the per-URL counter and move on.
         for (const url of evictedUrls) {
-          try { await clearHealth(env, url); } catch { /* CF-017 — best-effort; a per-URL failure must not abort the eviction loop */ }
+          try {
+            await clearHealth(env, url);
+          } catch (err) {
+            log('warn', 'discovery.completed', {
+              status: 'clear_health_failed',
+              scrape_run_id,
+              tag,
+              url,
+              detail: String(err).slice(0, 500),
+            });
+          }
         }
         continue;
       }
@@ -813,7 +823,17 @@ export async function applyEvictions(
           tag,
         });
         for (const url of evictedUrls) {
-          try { await clearHealth(env, url); } catch { /* CF-017 — best-effort; a per-URL failure must not abort the eviction loop */ }
+          try {
+            await clearHealth(env, url);
+          } catch (err) {
+            log('warn', 'discovery.completed', {
+              status: 'clear_health_failed',
+              scrape_run_id,
+              tag,
+              url,
+              detail: String(err).slice(0, 500),
+            });
+          }
         }
         continue;
       }
@@ -827,8 +847,18 @@ export async function applyEvictions(
       // Clear the per-URL health counters so a re-discovered URL at
       // the same address starts from a clean slate.
       for (const url of evictedUrls) {
-          try { await clearHealth(env, url); } catch { /* CF-017 — best-effort; a per-URL failure must not abort the eviction loop */ }
+        try {
+          await clearHealth(env, url);
+        } catch (err) {
+          log('warn', 'discovery.completed', {
+            status: 'clear_health_failed',
+            scrape_run_id,
+            tag,
+            url,
+            detail: String(err).slice(0, 500),
+          });
         }
+      }
 
       log('warn', 'discovery.completed', {
         status: 'feed_evicted',

--- a/src/queue/scrape-finalize-consumer.ts
+++ b/src/queue/scrape-finalize-consumer.ts
@@ -45,7 +45,7 @@
 import { log } from '~/lib/log';
 import { applyForeignKeysPragma } from '~/lib/db';
 import { FALLBACK_MODEL_ID } from '~/lib/models';
-import { FINALIZE_DEDUP_SYSTEM, finalizeDedupUserPrompt, LLM_PARAMS } from '~/lib/prompts';
+import { FINALIZE_DEDUP_SYSTEM, finalizeDedupUserPrompt, FINALIZE_LLM_PARAMS } from '~/lib/prompts';
 import { parseLLMJson } from '~/lib/generate';
 import { runJsonWithFallback } from '~/lib/llm-json';
 import { pickWinner, buildMergeStatements, type FinalizeRow } from '~/lib/finalize-merge';
@@ -167,7 +167,7 @@ export async function processOneFinalize(
         { role: 'system', content: FINALIZE_DEDUP_SYSTEM },
         { role: 'user', content: finalizeDedupUserPrompt(candidates) },
       ],
-      ...LLM_PARAMS,
+      ...FINALIZE_LLM_PARAMS,
     },
     narrow: (raw) => parseLLMJson(raw),
     onPrimaryFailure: (info) => {

--- a/tests/auth/middleware.test.ts
+++ b/tests/auth/middleware.test.ts
@@ -7,7 +7,6 @@
 
 import { describe, it, expect, vi } from 'vitest';
 import {
-  readCookie,
   buildSessionCookie,
   buildClearSessionCookie,
   loadSession,
@@ -16,6 +15,7 @@ import {
   requireSession,
   SESSION_COOKIE_NAME,
 } from '~/middleware/auth';
+import { readCookie } from '~/lib/crypto';
 import { signSession } from '~/lib/session-jwt';
 
 /**

--- a/tests/lib/prompts.test.ts
+++ b/tests/lib/prompts.test.ts
@@ -4,18 +4,35 @@
 // they are no longer exported.
 import { describe, it, expect } from 'vitest';
 import {
-  LLM_PARAMS,
+  CHUNK_LLM_PARAMS,
+  FINALIZE_LLM_PARAMS,
+  DISCOVERY_LLM_PARAMS,
   DISCOVERY_SYSTEM,
   PROCESS_CHUNK_SYSTEM,
   discoveryUserPrompt,
   processChunkUserPrompt,
 } from '~/lib/prompts';
 
-describe('LLM_PARAMS', () => {
-  it('LLM_PARAMS pins inference parameters', () => {
-    expect(LLM_PARAMS.temperature).toBe(0.6);
-    expect(LLM_PARAMS.max_tokens).toBe(50_000);
-    expect(LLM_PARAMS.response_format.type).toBe('json_object');
+describe('LLM param sets — REQ-PIPE-002 / REQ-PIPE-008 / REQ-DISC-001 (CF-023)', () => {
+  it('CHUNK_LLM_PARAMS is the chunk-sized variant (50K tokens) for multi-article output', () => {
+    expect(CHUNK_LLM_PARAMS.temperature).toBe(0.6);
+    expect(CHUNK_LLM_PARAMS.max_tokens).toBe(50_000);
+    expect(CHUNK_LLM_PARAMS.response_format.type).toBe('json_object');
+  });
+  it('FINALIZE_LLM_PARAMS is the small-payload variant (4K tokens) for dedup_groups output', () => {
+    expect(FINALIZE_LLM_PARAMS.temperature).toBe(0.6);
+    expect(FINALIZE_LLM_PARAMS.max_tokens).toBe(4_000);
+    expect(FINALIZE_LLM_PARAMS.response_format.type).toBe('json_object');
+  });
+  it('DISCOVERY_LLM_PARAMS is the small-payload variant (4K tokens) for feed-list output', () => {
+    expect(DISCOVERY_LLM_PARAMS.temperature).toBe(0.6);
+    expect(DISCOVERY_LLM_PARAMS.max_tokens).toBe(4_000);
+    expect(DISCOVERY_LLM_PARAMS.response_format.type).toBe('json_object');
+  });
+  it('the three param sets are distinct objects (no aliasing surprise)', () => {
+    expect(CHUNK_LLM_PARAMS).not.toBe(FINALIZE_LLM_PARAMS);
+    expect(CHUNK_LLM_PARAMS).not.toBe(DISCOVERY_LLM_PARAMS);
+    expect(CHUNK_LLM_PARAMS.max_tokens).not.toBe(FINALIZE_LLM_PARAMS.max_tokens);
   });
 });
 

--- a/tests/pipeline/cleanup.test.ts
+++ b/tests/pipeline/cleanup.test.ts
@@ -592,3 +592,85 @@ describe('cleanup cron — REQ-DISC-006 stuck-tag prune', () => {
     expect(await getUserHashtags(USER_ID)).toEqual(['ai']);
   });
 });
+
+describe('cleanup cron — CF-008 chunk_completions purge', () => {
+  beforeEach(async () => {
+    await env.DB.exec('DELETE FROM scrape_chunk_completions');
+    await env.DB.exec('DELETE FROM scrape_runs');
+  });
+
+  async function insertScrapeRun(
+    id: string,
+    finishedAt: number | null,
+    startedAt = nowSec() - 86400,
+  ): Promise<void> {
+    await env.DB
+      .prepare(
+        `INSERT INTO scrape_runs (id, started_at, finished_at, status)
+         VALUES (?1, ?2, ?3, ?4)`,
+      )
+      .bind(id, startedAt, finishedAt, finishedAt === null ? 'running' : 'success')
+      .run();
+  }
+
+  async function insertChunkCompletion(runId: string, seq: number): Promise<void> {
+    await env.DB
+      .prepare(
+        `INSERT INTO scrape_chunk_completions (scrape_run_id, chunk_seq, completed_at)
+         VALUES (?1, ?2, ?3)`,
+      )
+      .bind(runId, seq, nowSec())
+      .run();
+  }
+
+  it('CF-008: rows for runs whose finished_at is older than 14d are purged', async () => {
+    await insertScrapeRun('run-old', daysAgo(20));
+    await insertChunkCompletion('run-old', 0);
+    await insertChunkCompletion('run-old', 1);
+
+    const result = await runCleanup(env);
+
+    expect(result.chunkCompletionsPurged).toBeGreaterThanOrEqual(2);
+    expect(
+      await countRows(env.DB, 'scrape_chunk_completions', 'scrape_run_id = ?', 'run-old'),
+    ).toBe(0);
+  });
+
+  it('CF-008: rows for runs finished within the 14d window are preserved', async () => {
+    await insertScrapeRun('run-fresh', daysAgo(5));
+    await insertChunkCompletion('run-fresh', 0);
+
+    const result = await runCleanup(env);
+
+    expect(
+      await countRows(env.DB, 'scrape_chunk_completions', 'scrape_run_id = ?', 'run-fresh'),
+    ).toBe(1);
+    expect(result.chunkCompletionsPurged).toBe(0);
+  });
+
+  it('CF-008: rows for in-flight runs (finished_at IS NULL) are preserved', async () => {
+    await insertScrapeRun('run-running', null, nowSec() - 60);
+    await insertChunkCompletion('run-running', 0);
+
+    const result = await runCleanup(env);
+
+    expect(
+      await countRows(env.DB, 'scrape_chunk_completions', 'scrape_run_id = ?', 'run-running'),
+    ).toBe(1);
+    expect(result.chunkCompletionsPurged).toBe(0);
+  });
+
+  it('CF-008: orphan rows whose parent scrape_run row is missing are purged', async () => {
+    // Insert a completion row pointing at a run id that does not exist
+    // (simulates a finalize crash or manual abort that drops the run
+    // row but leaves children behind).
+    await insertChunkCompletion('run-ghost', 0);
+
+    const result = await runCleanup(env);
+
+    expect(result.chunkCompletionsPurged).toBeGreaterThanOrEqual(1);
+    expect(
+      await countRows(env.DB, 'scrape_chunk_completions', 'scrape_run_id = ?', 'run-ghost'),
+    ).toBe(0);
+  });
+});

--- a/tests/pipeline/cleanup.test.ts
+++ b/tests/pipeline/cleanup.test.ts
@@ -622,7 +622,7 @@ describe('cleanup cron — CF-008 chunk_completions purge', () => {
   async function insertChunkCompletion(runId: string, seq: number): Promise<void> {
     await env.DB
       .prepare(
-        `INSERT INTO scrape_chunk_completions (scrape_run_id, chunk_seq, completed_at)
+        `INSERT INTO scrape_chunk_completions (scrape_run_id, chunk_index, completed_at)
          VALUES (?1, ?2, ?3)`,
       )
       .bind(runId, seq, nowSec())

--- a/tests/pipeline/cleanup.test.ts
+++ b/tests/pipeline/cleanup.test.ts
@@ -606,10 +606,16 @@ describe('cleanup cron — CF-008 chunk_completions purge', () => {
   ): Promise<void> {
     await env.DB
       .prepare(
-        `INSERT INTO scrape_runs (id, started_at, finished_at, status)
-         VALUES (?1, ?2, ?3, ?4)`,
+        `INSERT INTO scrape_runs (id, started_at, finished_at, status, model_id)
+         VALUES (?1, ?2, ?3, ?4, ?5)`,
       )
-      .bind(id, startedAt, finishedAt, finishedAt === null ? 'running' : 'success')
+      .bind(
+        id,
+        startedAt,
+        finishedAt,
+        finishedAt === null ? 'running' : 'success',
+        '@cf/openai/gpt-oss-20b',
+      )
       .run();
   }
 


### PR DESCRIPTION
## Summary

PR3 of the 5-PR remediation. Stacked on PR2; targets main directly so CI fires (auto-cleans once PR1+PR2 merge).

## Findings addressed (12)

- **CF-003** — delete dead \`buildCollapsedSet\` + \`collapsedSet\` + void-suppress
- **CF-008** — wire \`scrape_chunk_completions\` cleanup into \`runCleanup\` (closes unbounded growth)
- **CF-009** — mark \`fanOutForTags\` + \`GENERIC_SOURCES\` as @internal; update stale Headline.source_tags JSDoc
- **CF-017** — applyEvictions: document byte-equal race-recheck invariant + per-URL try/catch on clearHealth
- **CF-021** — drop \`feed:\` prefix from discovered-feed source names (consistent with curated)
- **CF-022** — rename evictionNowSec → coordinatorNowSec (4 sites)
- **CF-023** — split LLM_PARAMS into CHUNK + FINALIZE variants (4K vs 50K max_tokens)
- **CF-025** — adaptersForDiscoveredFeeds gains {trusted: true} option for curated adapters (~70 SSRF-checks/tick saved)
- **CF-028** — promote FRESHNESS_WINDOW_SEC to module scope; add ChunkCandidate interface
- **CF-032** — delete readCookie shim in middleware/auth.ts
- **CF-033** — mark isKnownOAuthErrorCode as @internal (test-only)
- **CF-034** — promote normalizeHashtag + HASHTAG_REGEX to ~/lib/hashtags

## Deferred

- **CF-018** — deferred-candidates KV for chunk overflow. Needs producer + consumer sides + tests; scope creep risk for this PR.

## Test plan

- [ ] CI green
- [ ] Smoke: trigger force-refresh, confirm no source-name suffix regressions, confirm scrape_chunk_completions actually drops on cron tick