### PR TITLE
ui(landing): rewrite tagline in product voice

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -57,7 +57,7 @@ const errorMessage =
         wire story. Pick your hashtags. The LLM reads, you take the credit. It
         links to real sources and never declares itself a very stable genius.
         News like it's 1995, when 'fake news' meant Elvis sightings and the
-        worst thing a President had to deny was inhaling.
+        worst thing a President had to deny was inhaling. Minus the dial-up.
       </p>
 
       {errorMessage !== null && (

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -52,9 +52,12 @@ const errorMessage =
     <section class="landing__hero">
       <h1 class="landing__title">Your daily tech digest,<br />distilled by AI.</h1>
       <p class="landing__tagline">
-        Pick your hashtags. The LLM does the reading, you take the credit. Read
-        the news like it's 1995 — no cookie banners, no exit-intent modals, no
-        twelve articles about the same launch.
+        Where we're going, we don't need cookie banners. Or the floating chat
+        widget asking if you need help reading. Or six sites running the same
+        wire story. Pick your hashtags. The LLM reads, you take the credit. It
+        links to real sources and never declares itself a very stable genius.
+        News like it's 1995, when 'fake news' meant Elvis sightings and the
+        worst thing a President had to deny was inhaling.
       </p>
 
       {errorMessage !== null && (


### PR DESCRIPTION
## Summary

Single-line copy change: replace the marketing-team tagline on the landing page with one that matches the README voice. BTTF callback opener, three modern news grievances (cookie banners, chat widgets, wire-story duplication), implicit bipartisan political jabs ("very stable genius" → Trump; "didn't inhale" → Clinton), '95 nostalgia closer with Elvis sightings as the original benign meaning of "fake news."

## Test plan
- [ ] CI green
- [ ] Curl https://news.graymatter.ch/ after deploy and verify tagline renders correctly