### PR TITLE
feat(infra): integration deployment target (news.novoselec.ch)

### DIFF
--- a/.github/workflows/deploy-integration.yml
+++ b/.github/workflows/deploy-integration.yml
@@ -1,21 +1,21 @@
 name: Deploy Integration
 
-# Manual-only — pick a branch / tag / SHA in the Actions UI, deploys it
-# to the integration env on news.novoselec.ch. Use this to smoke-test
-# risky changes (Astro major bumps, schema migrations, CSP tightening)
-# on the live edge without touching production.
+# Auto-deploy on every push to develop (the staging branch). Mirrors
+# the production deploy.yml pattern: gates on PR Checks completing
+# green so a broken commit on develop never reaches the integration
+# environment. workflow_dispatch is kept as a manual fallback for
+# stuck deploys.
 #
 # All Cloudflare resources are env-scoped via wrangler.toml's
 # [env.integration] block — separate D1, KV, queues, all with
 # `-integration` suffixes. Crons are intentionally OFF on integration;
 # trigger scrape runs manually via /api/admin/force-refresh.
 on:
+  workflow_run:
+    workflows: ['PR Checks']
+    types: [completed]
+    branches: [develop]
   workflow_dispatch:
-    inputs:
-      ref:
-        description: 'Branch / tag / SHA to deploy to integration'
-        required: true
-        default: 'develop'
 
 concurrency:
   group: deploy-integration
@@ -27,6 +27,11 @@ permissions:
 jobs:
   deploy:
     name: Deploy to Cloudflare Workers (integration)
+    # On workflow_run: only deploy when PR Checks ended green on the
+    # develop SHA. On workflow_dispatch (manual re-run): always run.
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success')
     runs-on: ubuntu-latest
     timeout-minutes: 15
     # GitHub Environment named "integration" — store integration-only
@@ -36,9 +41,14 @@ jobs:
     # not a secret).
     environment: integration
     steps:
+      # On workflow_run we want the SHA the PR-Checks run was for, not
+      # the workflow file's branch (workflow_run defaults to the
+      # workflow's own ref, which can be stale). On manual dispatch the
+      # checkout default — the branch the dispatch was fired from — is
+      # right.
       - uses: actions/checkout@v6
         with:
-          ref: ${{ inputs.ref }}
+          ref: ${{ github.event.workflow_run.head_sha || github.ref }}
 
       - uses: actions/setup-node@v6
         with:

--- a/.github/workflows/deploy-integration.yml
+++ b/.github/workflows/deploy-integration.yml
@@ -1,0 +1,253 @@
+name: Deploy Integration
+
+# Manual-only — pick a branch / tag / SHA in the Actions UI, deploys it
+# to the integration env on news.novoselec.ch. Use this to smoke-test
+# risky changes (Astro major bumps, schema migrations, CSP tightening)
+# on the live edge without touching production.
+#
+# All Cloudflare resources are env-scoped via wrangler.toml's
+# [env.integration] block — separate D1, KV, queues, all with
+# `-integration` suffixes. Crons are intentionally OFF on integration;
+# trigger scrape runs manually via /api/admin/force-refresh.
+on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: 'Branch / tag / SHA to deploy to integration'
+        required: true
+        default: 'develop'
+
+concurrency:
+  group: deploy-integration
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  deploy:
+    name: Deploy to Cloudflare Workers (integration)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    # GitHub Environment named "integration" — store integration-only
+    # secrets here (OAUTH_JWT_SECRET, GOOGLE_OAUTH_CLIENT_ID, etc.) so
+    # they don't bleed into the production deploy. APP_URL is set in
+    # wrangler.toml [env.integration.vars] (it's the public hostname,
+    # not a secret).
+    environment: integration
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.ref }}
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '22'
+
+      - name: Install dependencies
+        run: npm install --no-fund --no-audit
+
+      - name: Build
+        run: npm run build
+
+      - name: Create .assetsignore (exclude _worker.js from asset upload)
+        run: |
+          printf '_worker.js\n_routes.json\n' > dist/.assetsignore
+
+      - name: Bootstrap Cloudflare resources (integration, idempotent)
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          ENV_NAME: integration
+        run: bash scripts/bootstrap-resources.sh
+
+      - name: Apply D1 migrations (integration)
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: npx --yes wrangler d1 migrations apply DB --remote --env integration
+
+      - name: Push Worker secrets (integration)
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          GOOGLE_OAUTH_CLIENT_ID: ${{ secrets.GOOGLE_OAUTH_CLIENT_ID }}
+          GOOGLE_OAUTH_CLIENT_SECRET: ${{ secrets.GOOGLE_OAUTH_CLIENT_SECRET }}
+          OAUTH_JWT_SECRET: ${{ secrets.OAUTH_JWT_SECRET }}
+        run: |
+          set -e
+          # Required.
+          for name in OAUTH_JWT_SECRET; do
+            if [ -z "${!name:-}" ]; then
+              echo "::error::Required secret '$name' is not set in the integration environment." \
+                   "Add it under Settings → Environments → integration → Add secret."
+              exit 1
+            fi
+            TMP=$(mktemp)
+            printf '%s' "${!name}" > "$TMP"
+            npx --yes wrangler secret put "$name" --env integration < "$TMP"
+            rm "$TMP"
+          done
+
+          # Sign-in providers — Google only on integration (per
+          # operator decision: skip GitHub OAuth setup on integration,
+          # use Google to sign in for testing). The landing page renders
+          # one button per configured provider, so the GitHub button
+          # simply doesn't appear.
+          if [ -n "${GOOGLE_OAUTH_CLIENT_ID:-}" ] && [ -n "${GOOGLE_OAUTH_CLIENT_SECRET:-}" ]; then
+            for name in GOOGLE_OAUTH_CLIENT_ID GOOGLE_OAUTH_CLIENT_SECRET; do
+              TMP=$(mktemp)
+              printf '%s' "${!name}" > "$TMP"
+              npx --yes wrangler secret put "$name" --env integration < "$TMP"
+              rm "$TMP"
+            done
+            echo "Google sign-in: configured"
+          else
+            echo "::error::Google sign-in not configured for integration." \
+                 "Add GOOGLE_OAUTH_CLIENT_ID + GOOGLE_OAUTH_CLIENT_SECRET to" \
+                 "Settings → Environments → integration."
+            exit 1
+          fi
+
+          # Resend skipped on integration — daily-digest emails disabled.
+          # DEV_BYPASS_TOKEN skipped — no e2e tests against integration yet.
+          # ADMIN_EMAIL / CF_ACCESS_AUD skipped — admin endpoints return 403,
+          # which is the correct default for a single-operator integration env.
+
+      - name: Deploy (integration)
+        id: deploy
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: |
+          set -o pipefail
+          # Same duplicate-key warning filter as deploy.yml — Astro's
+          # bundled `entities` dependency emits harmless dup-key warnings.
+          npx --yes wrangler deploy --env integration 2>&1 | tee deploy.log | \
+            awk '
+              /^▲ \[WARNING\] Duplicate key ".*" in object literal \[duplicate-object-key\]/ { skip=1; next }
+              skip && /^$/ { skip=0; next }
+              skip { next }
+              { print }
+            '
+          WORKER_URL=$(grep -oE 'https://[^ ]+\.workers\.dev' deploy.log | head -n1 || true)
+          echo "worker_url=$WORKER_URL" >> "$GITHUB_OUTPUT"
+          echo "Deployed to: $WORKER_URL"
+
+      - name: Bind custom domain (integration)
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: |
+          set -e
+          # APP_URL on integration is set in wrangler.toml [env.integration.vars],
+          # not as a secret. Read it directly from the toml so the bind step
+          # has a canonical source.
+          APP_URL=$(awk '
+            $0 == "[env.integration.vars]" { in_sec=1; next }
+            /^\[/ && in_sec { in_sec=0 }
+            in_sec && $1 == "APP_URL" {
+              n = split($0, parts, "\"")
+              if (n >= 2) { print parts[2]; exit }
+            }
+          ' wrangler.toml)
+
+          if [ -z "$APP_URL" ]; then
+            echo "APP_URL not found in wrangler.toml [env.integration.vars]; skipping custom-domain binding"
+            exit 0
+          fi
+          HOST=$(printf '%s' "$APP_URL" | sed -E 's|^[A-Za-z]+://||; s|/.*$||; s|:.*$||')
+          if [ -z "$HOST" ]; then
+            echo "Could not extract hostname from APP_URL; skipping"
+            exit 0
+          fi
+          case "$HOST" in
+            *.*) : ;;
+            *)
+              echo "APP_URL hostname '$HOST' is not fully-qualified; skipping bind"
+              exit 0
+              ;;
+          esac
+          echo "Binding integration Worker to custom domain: $HOST"
+
+          # Worker service name from the env-scoped block.
+          SERVICE=$(awk '
+            $0 == "[env.integration]" { in_sec=1; next }
+            /^\[/ && in_sec && $0 != "[env.integration]" { in_sec=0 }
+            in_sec && $1 == "name" {
+              n = split($0, parts, "\"")
+              if (n >= 2) { print parts[2]; exit }
+            }
+          ' wrangler.toml)
+          if [ -z "$SERVICE" ]; then
+            echo "Could not parse [env.integration].name from wrangler.toml"
+            exit 1
+          fi
+          echo "Worker service: $SERVICE"
+
+          # Find the zone for the hostname (host → ...rest.of.host → apex).
+          CANDIDATE="$HOST"
+          ZONE_ID=""
+          while [ -n "$CANDIDATE" ] && [ "$CANDIDATE" != "${CANDIDATE#*.}" ]; do
+            ZONE_ID=$(curl -fsS \
+              "https://api.cloudflare.com/client/v4/zones?name=$CANDIDATE" \
+              -H "Authorization: Bearer $CLOUDFLARE_API_TOKEN" \
+              | jq -r '.result[0].id // empty')
+            if [ -n "$ZONE_ID" ]; then
+              echo "Found zone for $CANDIDATE: $ZONE_ID"
+              break
+            fi
+            CANDIDATE="${CANDIDATE#*.}"
+          done
+          if [ -z "$ZONE_ID" ]; then
+            echo "No Cloudflare zone found for $HOST in this account; cannot bind custom domain"
+            exit 1
+          fi
+
+          BODY=$(jq -cn \
+            --arg z "$ZONE_ID" --arg h "$HOST" --arg s "$SERVICE" \
+            '{zone_id:$z, hostname:$h, service:$s, environment:"production"}')
+
+          RESP=$(mktemp)
+          HTTP_CODE=$(curl -sS -o "$RESP" -w "%{http_code}" -X PUT \
+            "https://api.cloudflare.com/client/v4/accounts/$CLOUDFLARE_ACCOUNT_ID/workers/domains" \
+            -H "Authorization: Bearer $CLOUDFLARE_API_TOKEN" \
+            -H "Content-Type: application/json" \
+            -d "$BODY")
+          SUCCESS=$(jq -r '.success' < "$RESP" 2>/dev/null || echo "")
+          if [ "$HTTP_CODE" != "200" ] || [ "$SUCCESS" != "true" ]; then
+            echo "Custom-domain bind failed (HTTP $HTTP_CODE):"
+            cat "$RESP"
+            rm -f "$RESP"
+            exit 1
+          fi
+          rm -f "$RESP"
+          echo "Custom domain $HOST → $SERVICE (zone $ZONE_ID) attached"
+
+      - name: Smoke test (integration)
+        env:
+          WORKER_URL: ${{ steps.deploy.outputs.worker_url }}
+        run: |
+          # Read APP_URL from wrangler.toml — same source the bind step used.
+          APP_URL=$(awk '
+            $0 == "[env.integration.vars]" { in_sec=1; next }
+            /^\[/ && in_sec { in_sec=0 }
+            in_sec && $1 == "APP_URL" {
+              n = split($0, parts, "\"")
+              if (n >= 2) { print parts[2]; exit }
+            }
+          ' wrangler.toml)
+
+          for URL in "$APP_URL" "$WORKER_URL"; do
+            if [ -z "$URL" ]; then continue; fi
+            CODE=$(curl -s --max-time 15 -o /dev/null -w "%{http_code}" "$URL/" || echo "000")
+            echo "GET $URL/ → HTTP $CODE"
+            case "$CODE" in
+              200|303)
+                echo "Integration smoke test passed via $URL"
+                exit 0
+                ;;
+            esac
+          done
+          echo "No reachable integration smoke-test URL"
+          exit 1

--- a/.github/workflows/deploy-integration.yml
+++ b/.github/workflows/deploy-integration.yml
@@ -1,20 +1,16 @@
 name: Deploy Integration
 
-# Auto-deploy on every push to develop (the staging branch). Mirrors
-# the production deploy.yml pattern: gates on PR Checks completing
-# green so a broken commit on develop never reaches the integration
-# environment. workflow_dispatch is kept as a manual fallback for
-# stuck deploys.
+# Manual trigger ONLY. Operator workflow: land changes on develop
+# normally; when ready to smoke-test on the live edge, hit
+# Actions → Deploy Integration → Run workflow. The deploy always
+# pulls from the current develop HEAD regardless of which branch
+# the dispatch was fired from in the UI.
 #
 # All Cloudflare resources are env-scoped via wrangler.toml's
 # [env.integration] block — separate D1, KV, queues, all with
 # `-integration` suffixes. Crons are intentionally OFF on integration;
 # trigger scrape runs manually via /api/admin/force-refresh.
 on:
-  workflow_run:
-    workflows: ['PR Checks']
-    types: [completed]
-    branches: [develop]
   workflow_dispatch:
 
 concurrency:
@@ -27,11 +23,6 @@ permissions:
 jobs:
   deploy:
     name: Deploy to Cloudflare Workers (integration)
-    # On workflow_run: only deploy when PR Checks ended green on the
-    # develop SHA. On workflow_dispatch (manual re-run): always run.
-    if: >-
-      github.event_name == 'workflow_dispatch' ||
-      (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success')
     runs-on: ubuntu-latest
     timeout-minutes: 15
     # GitHub Environment named "integration" — store integration-only
@@ -41,14 +32,12 @@ jobs:
     # not a secret).
     environment: integration
     steps:
-      # On workflow_run we want the SHA the PR-Checks run was for, not
-      # the workflow file's branch (workflow_run defaults to the
-      # workflow's own ref, which can be stale). On manual dispatch the
-      # checkout default — the branch the dispatch was fired from — is
-      # right.
+      # Always deploy develop's current HEAD regardless of which branch
+      # the dispatch was fired from in the UI. Develop is the single
+      # source of truth for what gets smoke-tested on integration.
       - uses: actions/checkout@v6
         with:
-          ref: ${{ github.event.workflow_run.head_sha || github.ref }}
+          ref: develop
 
       - uses: actions/setup-node@v6
         with:

--- a/scripts/bootstrap-resources.sh
+++ b/scripts/bootstrap-resources.sh
@@ -14,6 +14,11 @@
 # Required env:
 #   CLOUDFLARE_API_TOKEN
 #   CLOUDFLARE_ACCOUNT_ID
+#
+# Optional env:
+#   ENV_NAME  — when set (e.g. "integration"), operates on env-scoped
+#               sections like [[env.integration.d1_databases]]; otherwise
+#               operates on top-level sections (production deploys).
 
 set -euo pipefail
 
@@ -22,6 +27,24 @@ set -euo pipefail
 
 API="https://api.cloudflare.com/client/v4"
 AUTH_HEADER="Authorization: Bearer $CLOUDFLARE_API_TOKEN"
+
+# When ENV_NAME is set, prefix every section header with `env.<name>.` so
+# we operate on the environment-scoped resources instead of top-level.
+# When unset, leave the prefix empty (production / single-env path).
+ENV_NAME="${ENV_NAME:-}"
+if [ -n "$ENV_NAME" ]; then
+  SEC_PREFIX="env.${ENV_NAME}."
+  WORKER_NAME_HEADER="[env.${ENV_NAME}]"
+  echo "Bootstrap target: env=${ENV_NAME}"
+else
+  SEC_PREFIX=""
+  WORKER_NAME_HEADER=""
+  echo "Bootstrap target: production (top-level)"
+fi
+
+D1_HEADER="[[${SEC_PREFIX}d1_databases]]"
+KV_HEADER="[[${SEC_PREFIX}kv_namespaces]]"
+QUEUE_HEADER="[[${SEC_PREFIX}queues.producers]]"
 
 # ---------------------------------------------------------------- helpers
 cf_get() { curl -fsS -H "$AUTH_HEADER" "$API$1"; }
@@ -47,17 +70,36 @@ toml_scalar() {
   ' wrangler.toml
 }
 
+# Resolve the worker name for the current env target. Production uses the
+# top-level `name = ...`. Environment overrides live inside [env.<name>]
+# and re-declare `name`.
+resolve_worker_name() {
+  if [ -n "$WORKER_NAME_HEADER" ]; then
+    awk -v hdr="$WORKER_NAME_HEADER" '
+      $0 == hdr { in_section = 1; next }
+      /^\[/ && in_section { in_section = 0 }
+      in_section && $1 == "name" {
+        n = split($0, parts, "\"")
+        if (n >= 2) { print parts[2]; exit }
+      }
+    ' wrangler.toml
+  else
+    awk -F'"' '/^name[[:space:]]*=/ { print $2; exit }' wrangler.toml
+  fi
+}
+
 # ---------------------------------------------------- resource: D1 database
-D1_NAME=$(toml_scalar '[[d1_databases]]' 'database_name')
-D1_CURRENT=$(toml_scalar '[[d1_databases]]' 'database_id')
+D1_NAME=$(toml_scalar "$D1_HEADER" 'database_name')
+D1_CURRENT=$(toml_scalar "$D1_HEADER" 'database_id')
 if [ -z "$D1_NAME" ]; then
-  echo "ERROR: could not parse database_name from wrangler.toml"
+  echo "ERROR: could not parse database_name from wrangler.toml under $D1_HEADER"
   exit 1
 fi
 
 D1_ID=""
-# Step 1: is the pinned id present in this account?
-if [ -n "$D1_CURRENT" ]; then
+# Step 1: is the pinned id present in this account? (skip the 'TBD-...'
+# placeholder — that signals "no id yet, please bootstrap")
+if [ -n "$D1_CURRENT" ] && [[ "$D1_CURRENT" != TBD-* ]]; then
   if cf_get "/accounts/$CLOUDFLARE_ACCOUNT_ID/d1/database/$D1_CURRENT" \
       > /dev/null 2>&1; then
     D1_ID="$D1_CURRENT"
@@ -90,12 +132,16 @@ fi
 # wrangler.toml has no explicit name for the KV namespace (only the id +
 # binding). Derive a canonical title from the worker name so fork deploys
 # create a reusable namespace.
-WORKER_NAME=$(awk -F'"' '/^name[[:space:]]*=/ { print $2; exit }' wrangler.toml)
+WORKER_NAME=$(resolve_worker_name)
+if [ -z "$WORKER_NAME" ]; then
+  echo "ERROR: could not resolve worker name from wrangler.toml"
+  exit 1
+fi
 KV_TITLE="${WORKER_NAME}-kv"
-KV_CURRENT=$(toml_scalar '[[kv_namespaces]]' 'id')
+KV_CURRENT=$(toml_scalar "$KV_HEADER" 'id')
 
 KV_ID=""
-if [ -n "$KV_CURRENT" ]; then
+if [ -n "$KV_CURRENT" ] && [[ "$KV_CURRENT" != TBD-* ]]; then
   # Listing is the only read path for KV; check the id appears in the list.
   if cf_get "/accounts/$CLOUDFLARE_ACCOUNT_ID/storage/kv/namespaces?per_page=100" \
       | jq -e --arg id "$KV_CURRENT" '.result | any(.id == $id)' > /dev/null; then
@@ -124,12 +170,11 @@ if [ -z "$KV_ID" ]; then
 fi
 
 # ---------------------------------------------------------- resource: Queues
-# Iterate every `[[queues.producers]]` section in wrangler.toml (the
-# global-feed rework ships two: `scrape-coordinator` + `scrape-chunks`).
-# For each, check-or-create on Cloudflare so a fresh fork lands with the
-# queues pre-provisioned before `wrangler deploy` runs.
-QUEUE_NAMES=$(awk '
-  $0 == "[[queues.producers]]" { in_sec = 1; next }
+# Iterate every `[[queues.producers]]` section in wrangler.toml. For each,
+# check-or-create on Cloudflare so a fresh fork (or a fresh integration env)
+# lands with the queues pre-provisioned before `wrangler deploy` runs.
+QUEUE_NAMES=$(awk -v hdr="$QUEUE_HEADER" '
+  $0 == hdr { in_sec = 1; next }
   /^\[/ && in_sec { in_sec = 0 }
   in_sec && $1 == "queue" {
     n = split($0, parts, "\"")
@@ -138,7 +183,7 @@ QUEUE_NAMES=$(awk '
 ' wrangler.toml)
 
 if [ -z "$QUEUE_NAMES" ]; then
-  echo "ERROR: could not parse any queue names from wrangler.toml"
+  echo "ERROR: could not parse any queue names from wrangler.toml under $QUEUE_HEADER"
   exit 1
 fi
 
@@ -160,15 +205,16 @@ while IFS= read -r QUEUE_NAME; do
 done <<< "$QUEUE_NAMES"
 
 # -------------------------------------------------- patch wrangler.toml ids
-# Only touch the specific id lines inside [[d1_databases]] / [[kv_namespaces]]
-# so we don't accidentally rewrite anything else. The CI checkout is
-# ephemeral — this does not land back in the repo.
+# Only touch the specific id lines inside the targeted [[d1_databases]] /
+# [[kv_namespaces]] sections so we don't accidentally rewrite anything else.
+# When ENV_NAME is set, the env-scoped section is the target. The CI
+# checkout is ephemeral — this does not land back in the repo.
 
-# database_id (first occurrence under [[d1_databases]])
-awk -v new="$D1_ID" '
+# database_id (first occurrence under the targeted [[...d1_databases]])
+awk -v new="$D1_ID" -v hdr="$D1_HEADER" '
   BEGIN { in_sec=0; done=0 }
-  $0 == "[[d1_databases]]" { in_sec=1; print; next }
-  /^\[/ && in_sec && $0 != "[[d1_databases]]" { in_sec=0 }
+  $0 == hdr { in_sec=1; print; next }
+  /^\[/ && in_sec && $0 != hdr { in_sec=0 }
   in_sec && !done && $1 == "database_id" {
     print "database_id = \"" new "\""
     done=1
@@ -177,11 +223,11 @@ awk -v new="$D1_ID" '
   { print }
 ' wrangler.toml > wrangler.toml.tmp && mv wrangler.toml.tmp wrangler.toml
 
-# id (first occurrence under [[kv_namespaces]])
-awk -v new="$KV_ID" '
+# id (first occurrence under the targeted [[...kv_namespaces]])
+awk -v new="$KV_ID" -v hdr="$KV_HEADER" '
   BEGIN { in_sec=0; done=0 }
-  $0 == "[[kv_namespaces]]" { in_sec=1; print; next }
-  /^\[/ && in_sec && $0 != "[[kv_namespaces]]" { in_sec=0 }
+  $0 == hdr { in_sec=1; print; next }
+  /^\[/ && in_sec && $0 != hdr { in_sec=0 }
   in_sec && !done && $1 == "id" {
     print "id = \"" new "\""
     done=1
@@ -191,7 +237,7 @@ awk -v new="$KV_ID" '
 ' wrangler.toml > wrangler.toml.tmp && mv wrangler.toml.tmp wrangler.toml
 
 echo ""
-echo "Resolved resource ids:"
+echo "Resolved resource ids${ENV_NAME:+ (env=$ENV_NAME)}:"
 echo "  D1:     $D1_NAME = $D1_ID"
 echo "  KV:     $KV_TITLE = $KV_ID"
 while IFS= read -r QUEUE_NAME; do

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -69,3 +69,68 @@ crons = ["0 */4 * * *", "0 3 * * *", "*/5 * * * *"]
 
 [vars]
 # APP_URL is set as a Worker secret (different per deployment target)
+
+# ---------------------------------------------------------------------------
+# Integration environment — `wrangler deploy --env integration` targets a
+# fully isolated copy of every resource so risky changes (Astro major bumps,
+# CSP tightening, schema migrations) can be smoke-tested on the live edge
+# without touching production. All resources carry the `-integration`
+# suffix; cron triggers are intentionally OFF (no autonomous LLM spend on
+# integration; force-refresh via /api/admin/force-refresh for manual runs).
+# Bootstrap on first deploy: scripts/bootstrap-resources.sh creates the
+# resources by name, captures their IDs, and patches this file in CI.
+# ---------------------------------------------------------------------------
+
+[env.integration]
+name = "ai-news-digest-integration"
+main = "./dist/_worker.js/_merged.mjs"
+assets = { directory = "./dist", binding = "ASSETS" }
+
+[env.integration.observability]
+enabled = true
+
+[[env.integration.d1_databases]]
+binding = "DB"
+database_name = "ai-news-digest-integration"
+database_id = "TBD-bootstrap-on-first-deploy"
+migrations_dir = "./migrations"
+
+[[env.integration.kv_namespaces]]
+binding = "KV"
+id = "TBD-bootstrap-on-first-deploy"
+
+[[env.integration.queues.producers]]
+binding = "SCRAPE_COORDINATOR"
+queue = "scrape-coordinator-integration"
+
+[[env.integration.queues.producers]]
+binding = "SCRAPE_CHUNKS"
+queue = "scrape-chunks-integration"
+
+[[env.integration.queues.producers]]
+binding = "SCRAPE_FINALIZE"
+queue = "scrape-finalize-integration"
+
+[[env.integration.queues.consumers]]
+queue = "scrape-coordinator-integration"
+max_batch_size = 1
+max_retries = 3
+
+[[env.integration.queues.consumers]]
+queue = "scrape-chunks-integration"
+max_batch_size = 1
+max_retries = 3
+
+[[env.integration.queues.consumers]]
+queue = "scrape-finalize-integration"
+max_batch_size = 1
+max_retries = 3
+
+[env.integration.ai]
+binding = "AI"
+
+# No [env.integration.triggers] block — crons are intentionally disabled
+# on integration. Trigger scrape runs manually via /api/admin/force-refresh.
+
+[env.integration.vars]
+APP_URL = "https://news.novoselec.ch"


### PR DESCRIPTION
## Summary

Adds a fully-isolated **integration** environment so risky changes (Astro 5→6, schema migrations, CSP tightening, etc.) can be smoke-tested on the live edge without touching production. Three coordinated changes:

### 1. `wrangler.toml` — `[env.integration]` block

| Resource | Production | Integration |
|---|---|---|
| Worker | `ai-news-digest` | `ai-news-digest-integration` |
| D1 | `ai-news-digest` | `ai-news-digest-integration` |
| KV | derived `ai-news-digest-kv` | derived `ai-news-digest-integration-kv` |
| Queues | `scrape-{coordinator,chunks,finalize}` | `scrape-{coordinator,chunks,finalize}-integration` |
| Crons | `0 */4 * * *`, `0 3 * * *`, `*/5 * * * *` | **OFF** (manual force-refresh only) |
| `APP_URL` | secret (`news.graymatter.ch`) | `[env.integration.vars]` (`news.novoselec.ch`) |

`APP_URL` lives in the toml under `[env.integration.vars]` because it's a public hostname, not a secret. Crons are off to keep Workers AI spend bounded.

### 2. `scripts/bootstrap-resources.sh` — `ENV_NAME` support

The existing bootstrap script (idempotent D1/KV/queue create-or-lookup) is extended to accept an `ENV_NAME` env var. When set, it operates on env-scoped sections (e.g. `[[env.integration.d1_databases]]`); when unset, it preserves the production top-level path. Placeholder values like `database_id = "TBD-bootstrap-on-first-deploy"` trigger create-or-lookup-by-name on first run.

### 3. `.github/workflows/deploy-integration.yml` — manual workflow

`workflow_dispatch` with a branch-ref input. Pick a branch in the Actions UI, deploy it to integration. Uses GitHub Environment `integration` to scope secrets separately from production.

## Operator setup required before first run

1. **GitHub Environment "integration"** in repo Settings → Environments. Add secrets:
   - `OAUTH_JWT_SECRET` (per the discussion: same as prod is acceptable, separate is safer due to cross-env JWT identity confusion)
   - `GOOGLE_OAUTH_CLIENT_ID` (same as prod)
   - `GOOGLE_OAUTH_CLIENT_SECRET` (same as prod)
   - `CLOUDFLARE_API_TOKEN` + `CLOUDFLARE_ACCOUNT_ID` are inherited from the repo-level secrets.

2. **DNS for `news.novoselec.ch`** — assuming `novoselec.ch` is on the same Cloudflare account, the bind step uses the API to attach the hostname to the integration Worker. If the zone isn't on this account, the bind fails and you'll see it in the deploy log.

3. **Google OAuth client** — add `https://news.novoselec.ch/api/auth/google/callback` to the existing client's "Authorized redirect URIs" list.

GitHub OAuth is intentionally skipped on integration (per operator decision — only Google for testing). Resend is skipped (no daily-digest emails on integration).

## After this merges

Run **Actions → Deploy Integration → Run workflow**, pick `astro-6-bump` as the branch, and PR #178 (Astro 6) gets deployed to `news.novoselec.ch` for live smoke before any further work on it.

## Test plan

- [ ] CI green on this PR (no test changes; just config + script + workflow)
- [ ] After merge: GitHub Environment 'integration' configured with secrets
- [ ] After merge: first manual run of Deploy Integration with `ref=integration-environment` (or `develop`) succeeds
- [ ] `https://news.novoselec.ch/` returns 200 (landing page) or 303 (redirect to /digest if signed in)
- [ ] Sign in via Google works on integration

## What this does NOT do

- Does not change production deploys (production workflow + secrets unchanged)
- Does not migrate prod data — integration starts with a fresh, schema-only D1
- Does not run scrape automatically — manual `/api/admin/force-refresh` only