### PR TITLE
fix(history): re-bind star-delegation on astro:page-load

### DIFF
--- a/src/scripts/card-interactions.ts
+++ b/src/scripts/card-interactions.ts
@@ -183,6 +183,16 @@ export function closeAllTagPopovers(except?: HTMLElement): void {
 }
 
 // Auto-wire on DOMContentLoaded + every astro:page-load.
+//
+// IMPORTANT: bindStarDelegation MUST run on every astro:page-load, not
+// just module-load. Astro's default view-transition swap replaces the
+// entire `document.documentElement`, which discards both the bubble-
+// phase click listener AND the `data-star-delegation-bound` idempotency
+// flag we set on it. Re-running here is safe because the dataset guard
+// on the (fresh) documentElement is empty post-swap, so the helper
+// rebinds cleanly. Without this, navigating from /digest to /history
+// (or any cross-page nav) silently loses the star handler until the
+// user does a hard refresh.
 if (typeof document !== 'undefined') {
   bindStarDelegation();
   if (document.readyState === 'loading') {
@@ -190,5 +200,8 @@ if (typeof document !== 'undefined') {
   } else {
     initCardInteractions();
   }
-  document.addEventListener('astro:page-load', () => initCardInteractions());
+  document.addEventListener('astro:page-load', () => {
+    bindStarDelegation();
+    initCardInteractions();
+  });
 }


### PR DESCRIPTION
## Summary

Fixes the silent-favorites regression on `/history` (and any cross-page navigation): star button does nothing until the user does a hard browser refresh.

## Root cause

PR #175 consolidated the per-card star handler into a document-level click delegation (`bindStarDelegation`) to fix the same symptom on `/digest`. The helper attaches a bubble-phase listener to `document.documentElement` and sets `data-star-delegation-bound="1"` on the same element as an idempotency flag.

**The helper was only called once at module load.** Astro's default view-transition swap replaces `document.documentElement` on every navigation, which discards:
1. The bubble-phase click listener
2. The `data-star-delegation-bound` flag

Result: after navigating from `/digest` → `/history` (or vice versa), star clicks have no listener to bubble to. Hard reload re-runs the module and rebinds.

## Fix

Call `bindStarDelegation()` on every `astro:page-load`, not just module load. The dataset guard on the (fresh) documentElement is empty post-swap, so re-binding is idempotent and safe.

## Test plan

- [ ] CI green
- [ ] After deploy, navigate `/digest → /history` (or via brand-link), click a star button without hard-refreshing — toggle should fire immediately and persist after subsequent navigation.
- [ ] Repeat across `/digest`, `/history`, `/starred`, and the article-detail header where star buttons render.