### PR TITLE
fix(stars): listener idempotency must outlive view-transition swap

### DIFF
--- a/documentation/api-reference.md
+++ b/documentation/api-reference.md
@@ -428,6 +428,8 @@ Extended machine-readable agents policy (`public/llms-full.txt`). Superset of `l
 
 Each day group contains: `local_date`, `article_count`, `articles[]` (filtered to the user's active tags), `ticks[]` (scrape runs in that day), and per-day token/cost/articles-ingested aggregates.
 
+Each article in `articles[]` includes a `starred: boolean` field reflecting the authenticated user's current star state. The value is `true` when a row exists in `article_stars` for that `(user_id, article_id)` pair, `false` otherwise. This lets `/history` render the star glyph and `aria-pressed` state server-side on initial load without a separate fetch.
+
 `?q=` and `?tags=` are page-level URL state read client-side; they are not server query params.
 
 **Implements:** [REQ-HIST-001](../sdd/history.md#req-hist-001-day-grouped-article-history) AC 4, AC 5

--- a/documentation/api-reference.md
+++ b/documentation/api-reference.md
@@ -432,7 +432,7 @@ Each article in `articles[]` includes a `starred: boolean` field reflecting the 
 
 `?q=` and `?tags=` are page-level URL state read client-side; they are not server query params.
 
-**Implements:** [REQ-HIST-001](../sdd/history.md#req-hist-001-day-grouped-article-history) AC 4, AC 5
+**Implements:** [REQ-HIST-001](../sdd/history.md#req-hist-001-day-grouped-article-history) AC 4, AC 5; [REQ-STAR-001](../sdd/reading.md#req-star-001-star-and-unstar-articles) AC 6 (SSR-rendered initial star state per card)
 
 ### GET /api/stats
 

--- a/sdd/changes.md
+++ b/sdd/changes.md
@@ -8,6 +8,7 @@ Entries from 2026-04-22 through 2026-04-26 (the global-feed rework window) are a
 
 ## 2026-05-04
 
+- REQ-STAR-001 AC 1 broadened and AC 6 added: the spec now names every card surface that exposes a star toggle (dashboard, article detail, starred page, history day-expansions and search results) and requires each card to render its initial starred / unstarred state on first paint, so an article starred elsewhere shows up filled on `/history` without needing a hard refresh.
 - REQ-OPS-006 added: a parallel integration deployment target lets risky changes (Astro major bumps, schema migrations, CSP tightening, animation rewrites) be smoke-tested on the live Cloudflare edge before reaching production. Integration runs the same code on isolated Cloudflare resources (D1, KV, queues all suffixed `-integration`), is triggered manually only (Actions → Deploy Integration → Run workflow), always pulls develop's HEAD, and has cron triggers disabled so the operator drives the scrape pipeline via force-refresh. Forks set their own integration hostname under Settings → Environments → integration → Variables → APP_URL.
 - REQ-SET-004 corrected to Partial: the model-selection UI is hidden, but the settings API still validates and persists `model_id`. Full retirement awaits removing the field from the API and migrations.
 - REQ-OPS-007 added: public sitemap surfaced at `/sitemap.xml` for search-engine discovery, with authenticated routes deliberately excluded. The endpoint shipped earlier; this REQ captures the contract.

--- a/sdd/reading.md
+++ b/sdd/reading.md
@@ -163,11 +163,12 @@ The heart of the product. Overview grid of the freshest articles read from the s
 **Applies To:** User
 
 **Acceptance Criteria:**
-1. Every card in the dashboard grid and the article detail page shows a star toggle; activating it stars the article when unstarred and unstars it when starred.
+1. Every card that lists an article — the dashboard grid, the article detail page, the starred-articles page, and the day-expanded and search-result grids on `/history` — shows a star toggle; activating it stars the article when unstarred and unstars it when starred.
 2. Starring POSTs to the article-star endpoint; unstarring DELETEs the same endpoint; both flip the icon optimistically on click before the server response returns.
 3. Star state is user-scoped — starring an article in one account never reveals the star in any other account's view.
 4. State-changing star requests are protected by the Origin check from REQ-AUTH-003; unauthenticated requests receive HTTP 401.
 5. A successful star/unstar response confirms the new state and the UI reconciles with the server value if the optimistic flip disagreed.
+6. On every page that lists articles, each card renders its initial starred / unstarred state on first paint — articles the user has already starred appear filled and `aria-pressed` from the server-rendered HTML, without needing a hard refresh after a toggle on another page.
 
 **Constraints:** CON-SEC-001, CON-DATA-001
 **Priority:** P1

--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -422,6 +422,17 @@ const initialTheme = cookieTheme ?? 'light';
              H1 (48px+) so the brand still feels like navigation. */
           font-size: 40px;
         }
+        /* Icon must scale with the wordmark on desktop. Mobile keeps
+           text-2xl (32px) which matches the icon's intrinsic 32px so
+           `align-items: center` lands cap-height visually on the icon
+           midline. At desktop's 40px wordmark, a 32px icon centres
+           below the text's optical midline — the icon reads as
+           floating high relative to the wordmark. Match dimensions
+           so centre-alignment remains visually balanced. */
+        .site-header__mark {
+          width: 40px;
+          height: 40px;
+        }
       }
       /* "news" in muted, "digest" in full text — kerned together without
          whitespace. Gives the brand character without adding chrome. */

--- a/src/pages/api/history.ts
+++ b/src/pages/api/history.ts
@@ -125,31 +125,28 @@ export async function GET(context: APIContext): Promise<Response> {
 
   // --- Articles ---------------------------------------------------------
   // Restrict to articles in the window whose tag set intersects the
-  // user's active tags. Placeholders are positional (?1 = window,
-  // ?2..?N = tags) so tag slugs are bound, never string-interpolated.
+  // user's active tags.
+  //
+  // History groups by `ingested_at` — the day the scrape pipeline
+  // processed the article — NOT `published_at` (the feed's original
+  // publication timestamp). Rationale: a per-day row on /history
+  // ALSO shows tokens / cost / articles-ingested from scrape_runs
+  // whose `started_at` falls on that day; those are ingest-side
+  // numbers. If we grouped articles by published_at instead, a fresh
+  // wipe + rescrape would show articles distributed across ~10 days
+  // (feeds return ~10-day backlog) while tokens/cost concentrate on
+  // the one or two days the runs actually happened — a misleading
+  // schism. Keep selecting `published_at` so the wire payload still
+  // emits the feed's real publication time on each card; the GROUPING
+  // key is ingested_at, the DISPLAY key is published_at.
+  //
+  // Placeholder layout (positional, all values bound, none
+  // interpolated): ?1 = user_id, ?2 = window_start, ?3..?N = tag
+  // slugs. user_id slots first so the EXISTS join on article_stars
+  // can reference it independently of the variable-arity tag list.
   let articleRows: ArticleRow[] = [];
   if (userTags.length > 0) {
-    const tagPlaceholders = userTags.map((_, i) => `?${i + 2}`).join(', ');
-    // History groups by `ingested_at` — the day the scrape pipeline
-    // processed the article — NOT `published_at` (the feed's original
-    // publication timestamp). Rationale: a per-day row on /history
-    // ALSO shows tokens / cost / articles-ingested from
-    // scrape_runs whose `started_at` falls on that day; those are
-    // ingest-side numbers. If we grouped articles by published_at
-    // instead, a fresh wipe + rescrape would show articles
-    // distributed across ~10 days (feeds return ~10-day backlog)
-    // while tokens/cost concentrate on the one or two days the runs
-    // actually happened — a misleading schism.
-    //
-    // Keep selecting `published_at` so the wire payload still emits
-    // the feed's real publication time on each card (users read
-    // articles by when the news happened); the GROUPING key is
-    // ingested_at, the DISPLAY key is published_at.
-    // Per-user star state joins via EXISTS so a missing row produces
-    // `starred = 0` instead of dropping the article from the result.
-    // The user_id placeholder slots in BEFORE the window/tag binds —
-    // ?1 is user_id, ?2 is window_start, ?3..?N are tag slugs.
-    const userIdPlaceholderShift = userTags.map((_, i) => `?${i + 3}`).join(', ');
+    const tagPlaceholders = userTags.map((_, i) => `?${i + 3}`).join(', ');
     const articlesSql =
       `SELECT a.id, a.title, a.primary_source_name, a.primary_source_url, ` +
       `a.published_at, a.ingested_at, a.details_json, ` +
@@ -158,7 +155,7 @@ export async function GET(context: APIContext): Promise<Response> {
       `EXISTS(SELECT 1 FROM article_stars st WHERE st.article_id = a.id AND st.user_id = ?1) AS starred ` +
       `FROM articles a ` +
       `WHERE a.ingested_at >= ?2 ` +
-      `AND a.id IN (SELECT DISTINCT article_id FROM article_tags WHERE tag IN (${userIdPlaceholderShift})) ` +
+      `AND a.id IN (SELECT DISTINCT article_id FROM article_tags WHERE tag IN (${tagPlaceholders})) ` +
       `ORDER BY a.ingested_at DESC`;
     try {
       const result = await env.DB

--- a/src/pages/api/history.ts
+++ b/src/pages/api/history.ts
@@ -44,6 +44,9 @@ interface ArticleRow {
   ingested_at: number;
   details_json: string | null;
   tags_json: string | null;
+  /** 1 when a row exists in `article_stars` for this (user, article),
+   *  0 otherwise. SQLite returns INTEGER from EXISTS. */
+  starred: number;
 }
 
 /** Row shape for the scrape_runs query. */
@@ -69,6 +72,12 @@ export interface WireArticle {
   published_at: number;
   details: string[];
   tags: string[];
+  /** Per-user star state. Drives the DigestCard's initial
+   *  aria-pressed + filled/outline glyph render on /history. Without
+   *  this, articles the user has already starred render as un-starred
+   *  on the history dashboard until a hard refresh AFTER the user
+   *  toggles them again. */
+  starred: boolean;
 }
 
 /** Wire shape for a scrape_runs tick inside a day group. */
@@ -136,19 +145,25 @@ export async function GET(context: APIContext): Promise<Response> {
     // the feed's real publication time on each card (users read
     // articles by when the news happened); the GROUPING key is
     // ingested_at, the DISPLAY key is published_at.
+    // Per-user star state joins via EXISTS so a missing row produces
+    // `starred = 0` instead of dropping the article from the result.
+    // The user_id placeholder slots in BEFORE the window/tag binds —
+    // ?1 is user_id, ?2 is window_start, ?3..?N are tag slugs.
+    const userIdPlaceholderShift = userTags.map((_, i) => `?${i + 3}`).join(', ');
     const articlesSql =
       `SELECT a.id, a.title, a.primary_source_name, a.primary_source_url, ` +
       `a.published_at, a.ingested_at, a.details_json, ` +
       `(SELECT json_group_array(DISTINCT at.tag) FROM article_tags at ` +
-      `WHERE at.article_id = a.id) AS tags_json ` +
+      `WHERE at.article_id = a.id) AS tags_json, ` +
+      `EXISTS(SELECT 1 FROM article_stars st WHERE st.article_id = a.id AND st.user_id = ?1) AS starred ` +
       `FROM articles a ` +
-      `WHERE a.ingested_at >= ?1 ` +
-      `AND a.id IN (SELECT DISTINCT article_id FROM article_tags WHERE tag IN (${tagPlaceholders})) ` +
+      `WHERE a.ingested_at >= ?2 ` +
+      `AND a.id IN (SELECT DISTINCT article_id FROM article_tags WHERE tag IN (${userIdPlaceholderShift})) ` +
       `ORDER BY a.ingested_at DESC`;
     try {
       const result = await env.DB
         .prepare(articlesSql)
-        .bind(windowStart, ...userTags)
+        .bind(user.id, windowStart, ...userTags)
         .all<ArticleRow>();
       articleRows = result.results ?? [];
     } catch (err) {
@@ -202,6 +217,7 @@ export async function GET(context: APIContext): Promise<Response> {
       published_at: row.published_at,
       details: parseStringArray(row.details_json),
       tags: parseStringArray(row.tags_json),
+      starred: row.starred === 1,
     });
     group.article_count += 1;
   }

--- a/src/pages/api/history.ts
+++ b/src/pages/api/history.ts
@@ -1,4 +1,6 @@
 // Implements REQ-HIST-001
+// Implements REQ-STAR-001 (per-user star state surfaced on /history;
+//   user-scoping enforced by the `user_id = ?1` bind in the EXISTS join)
 //
 // GET /api/history — day-grouped view of the last 14 days of articles
 // that match the authenticated user's active tags, plus per-day

--- a/src/pages/digest/[id]/[slug].astro
+++ b/src/pages/digest/[id]/[slug].astro
@@ -554,9 +554,24 @@ const articleDataset = {
        absorbing the 0.30em overrun plus a small mobile pixel-
        rounding buffer without ever clipping the rendered glyph;
        line 3 then flows full-width. The safe upper bound on the
-       negative margin is 1 − cap_h − ascent_pad ≈ 1.22em — pushing
-       past it would start clipping the cap itself. */
-    margin: 0 0.1em -0.34em 0;
+       negative margin is 1 − cap_h − ascent_pad ≈ 1.22em − pushing
+       past it would start clipping the cap itself.
+
+       margin-top: the original tuning assumed Charter's ascent
+       ratio (≈0.78), which leaves ~0.79em of empty space above the
+       cap inside the 3.6em float box. Charter ships only on Apple
+       platforms; on Linux/Windows the stack falls back to Source
+       Serif Pro, Noto Serif, Cambria, or Times — these carry MORE
+       upper padding (ascent ratios 0.65–0.72), so the cap-top lands
+       ~0.3em LOWER than the math predicted, sitting below line 1's
+       cap-top instead of aligned with it. The negative margin-top
+       hauls the float upward to compensate, anchoring cap-top at
+       line 1's cap-top across the whole stack. The value is the
+       average shift across non-Charter fallbacks; on Charter itself
+       (-0.15em above its expected position) the cap still sits
+       within ~3 px of line 1's cap-top — within the optical noise
+       floor for a drop cap. */
+    margin: -0.3em 0.1em -0.34em 0;
     padding: 0;
   }
 

--- a/src/pages/digest/[id]/[slug].astro
+++ b/src/pages/digest/[id]/[slug].astro
@@ -554,7 +554,7 @@ const articleDataset = {
        absorbing the 0.30em overrun plus a small mobile pixel-
        rounding buffer without ever clipping the rendered glyph;
        line 3 then flows full-width. The safe upper bound on the
-       negative margin is 1 − cap_h − ascent_pad ≈ 1.22em − pushing
+       negative margin is 1 − cap_h − ascent_pad ≈ 1.22em — pushing
        past it would start clipping the cap itself.
 
        margin-top: the original tuning assumed Charter's ascent

--- a/src/pages/history.astro
+++ b/src/pages/history.astro
@@ -235,6 +235,7 @@ function formatCostUsd(value: number | null | undefined): string {
           sourceUrl={a.primary_source_url}
           oneLiner={a.details[0] ?? ''}
           tags={a.tags.filter((t) => userTagSet.has(t))}
+          starred={a.starred}
         />
       ))}
     </div>
@@ -291,6 +292,7 @@ function formatCostUsd(value: number | null | undefined): string {
                           sourceName={a.primary_source_name}
                           sourceUrl={a.primary_source_url}
                           tags={a.tags.filter((t) => userTagSet.has(t))}
+                          starred={a.starred}
                           index={i}
                           suppressTransition={isFilteringByTag}
                         />

--- a/src/scripts/card-interactions.ts
+++ b/src/scripts/card-interactions.ts
@@ -32,6 +32,25 @@
 const POPOVER_TTL_MS = 5000;
 const popoverTimers = new WeakMap<HTMLElement, number>();
 
+// Idempotency flags MUST live in this module's closure, NOT on a DOM
+// node attribute. Astro's default view-transition swap replaces
+// `document.documentElement` (so any `dataset.*` flag we set on it is
+// erased), but the `document` object itself is preserved across the
+// swap — so the click listener we registered on `document` persists.
+// The previous fix (PR #182) put the listener on `document` but the
+// flag on `documentElement.dataset`. After the first cross-page nav
+// the flag was clear while the listener was still live, so the
+// `astro:page-load` re-bind path stacked a SECOND listener. Every
+// subsequent star click fired two racing toggles (POST + DELETE) and
+// the star UI flipped to a non-deterministic end state — surfaced as
+// "marking anything as favorite is broken everywhere".
+//
+// Module-scope booleans pair correctly with the document-scope
+// listeners: both live as long as the module's closure does, neither
+// resets on view-transition.
+let starDelegationBound = false;
+let outsideClickBound = false;
+
 /**
  * Wire every tag-disclosure trigger under {@link root} with click
  * handlers. Re-entrant: triggers already bound are skipped. Returns
@@ -60,14 +79,11 @@ export function initCardInteractions(
     },
   );
 
-  // Outside-click closes any open popover. Bound ONCE globally via
-  // a documentElement flag so we don't stack listeners on astro:
-  // page-load re-entries.
-  if (
-    root === document &&
-    document.documentElement.dataset['cardOutsideClickBound'] !== '1'
-  ) {
-    document.documentElement.dataset['cardOutsideClickBound'] = '1';
+  // Outside-click closes any open popover. Bound ONCE per module
+  // lifetime via a closure flag (see comment near the flag declaration
+  // for why this can't live on documentElement.dataset).
+  if (root === document && !outsideClickBound) {
+    outsideClickBound = true;
     document.addEventListener('click', (e) => {
       const target = e.target;
       if (!(target instanceof Element)) return;
@@ -81,8 +97,8 @@ export function initCardInteractions(
 }
 
 /**
- * Bind the document-level star-click delegation. Idempotent via
- * `data-star-delegation-bound` on documentElement so re-imports or
+ * Bind the document-level star-click delegation. Idempotent via the
+ * module-scope `starDelegationBound` closure flag so re-imports or
  * astro:page-load re-runs never stack listeners. Exported for unit
  * tests that need to assert idempotency without driving the full
  * module-load side effects.
@@ -93,8 +109,8 @@ export function initCardInteractions(
  */
 export function bindStarDelegation(): void {
   if (typeof document === 'undefined') return;
-  if (document.documentElement.dataset['starDelegationBound'] === '1') return;
-  document.documentElement.dataset['starDelegationBound'] = '1';
+  if (starDelegationBound) return;
+  starDelegationBound = true;
   document.addEventListener('click', (e) => {
     const target = e.target;
     if (!(target instanceof Element)) return;
@@ -184,15 +200,14 @@ export function closeAllTagPopovers(except?: HTMLElement): void {
 
 // Auto-wire on DOMContentLoaded + every astro:page-load.
 //
-// IMPORTANT: bindStarDelegation MUST run on every astro:page-load, not
-// just module-load. Astro's default view-transition swap replaces the
-// entire `document.documentElement`, which discards both the bubble-
-// phase click listener AND the `data-star-delegation-bound` idempotency
-// flag we set on it. Re-running here is safe because the dataset guard
-// on the (fresh) documentElement is empty post-swap, so the helper
-// rebinds cleanly. Without this, navigating from /digest to /history
-// (or any cross-page nav) silently loses the star handler until the
-// user does a hard refresh.
+// bindStarDelegation is safe to call on every astro:page-load — its
+// closure-flag idempotency guarantees a single listener regardless of
+// how many times the page-load event fires. initCardInteractions is
+// called per page-load because tag-disclosure triggers ARE per-button
+// and need rebinding when new cards enter the DOM (e.g. /history's
+// day-grouped grids that lazy-render on `<details>` open). The
+// `data-bound` per-trigger guard inside initCardInteractions keeps
+// re-runs idempotent at the per-trigger level.
 if (typeof document !== 'undefined') {
   bindStarDelegation();
   if (document.readyState === 'loading') {

--- a/src/scripts/card-interactions.ts
+++ b/src/scripts/card-interactions.ts
@@ -52,6 +52,19 @@ let starDelegationBound = false;
 let outsideClickBound = false;
 
 /**
+ * Test-only helper. Resets the module-scope idempotency flags so the
+ * unit tests can re-exercise `bindStarDelegation` / `initCardInteractions`
+ * from a clean slate without resorting to `vi.resetModules()` + dynamic
+ * imports. The production runtime never calls this — flags are
+ * single-binding by design and there is no use case for clearing them
+ * mid-session. Exported behind a `__` prefix so it's visibly internal.
+ */
+export function __resetForTests(): void {
+  starDelegationBound = false;
+  outsideClickBound = false;
+}
+
+/**
  * Wire every tag-disclosure trigger under {@link root} with click
  * handlers. Re-entrant: triggers already bound are skipped. Returns
  * the number of triggers newly bound so tests can assert on it.

--- a/tests/history/api.test.ts
+++ b/tests/history/api.test.ts
@@ -35,6 +35,11 @@ interface ArticleRow {
   ingested_at: number;
   details_json: string | null;
   tags_json: string | null;
+  // REQ-STAR-001 — `EXISTS(...) AS starred` returns INTEGER 0/1; the
+  // production handler maps `row.starred === 1` to a boolean. Fakes
+  // default to 0 (un-starred); tests asserting on starred state can
+  // override per article.
+  starred: number;
 }
 
 interface ScrapeRunRow {
@@ -77,6 +82,7 @@ function fakeArticle(id: string, publishedAt: number, tags: string[]): ArticleRo
     ingested_at: publishedAt,
     details_json: JSON.stringify(['details']),
     tags_json: JSON.stringify(tags),
+    starred: 0,
   };
 }
 
@@ -263,12 +269,15 @@ describe('GET /api/history — REQ-HIST-001', () => {
 
     const articleBind = bindings.find((b) => b.sql.startsWith('SELECT a.id, a.title'));
     expect(articleBind).toBeDefined();
-    // ?1 = window cutoff, ?2..?N = tags. Both tags must be bound.
+    // REQ-STAR-001 added a per-user EXISTS join on article_stars to
+    // surface the starred glyph on /history. Bind shape is now
+    // ?1 = user_id, ?2 = window cutoff, ?3..?N = tags.
     expect(articleBind!.sql).toContain('article_tags');
     expect(articleBind!.sql).toContain('tag IN');
+    expect(articleBind!.sql).toContain('article_stars');
     const params = articleBind!.params;
-    expect(params.length).toBe(3); // cutoff + 2 tags
-    expect(params.slice(1)).toEqual(['ai', 'cloudflare']);
+    expect(params.length).toBe(4); // user_id + cutoff + 2 tags
+    expect(params.slice(2)).toEqual(['ai', 'cloudflare']);
   });
 
   it('REQ-HIST-001: empty pool returns { days: [] }', async () => {

--- a/tests/reading/card-interactions.test.ts
+++ b/tests/reading/card-interactions.test.ts
@@ -347,14 +347,20 @@ describe('initCardInteractions — REQ-STAR-001 + REQ-READ-001 event plumbing', 
     // listener owns every star-toggle click. A double-bind would fire
     // two fetches per click (POST + DELETE) and the optimistic toggle
     // would oscillate. Tracks addEventListener calls on a stubbed
-    // documentElement so we can assert the bound count is exactly 1
-    // even after multiple init invocations (simulating astro:page-load
+    // document so we can assert the bound count is exactly 1 even
+    // after multiple init invocations (simulating astro:page-load
     // re-fires).
-    const dataset: Record<string, string> = {};
-    const docElement = { dataset } as unknown as HTMLElement;
+    //
+    // Idempotency now lives in a module-scope closure flag, NOT on
+    // documentElement.dataset — Astro's view-transition swap replaces
+    // documentElement on every cross-page navigation, which previously
+    // erased the flag while the listener (registered on document, the
+    // node that survives the swap) lived on. The result was that
+    // astro:page-load re-binds stacked a second listener and every
+    // star click fired POST + DELETE in parallel.
     const calls: { type: string; useCapture: boolean }[] = [];
     vi.stubGlobal('document', {
-      documentElement: docElement,
+      documentElement: { dataset: {} } as unknown as HTMLElement,
       addEventListener: (
         type: string,
         _listener: EventListener,
@@ -375,8 +381,21 @@ describe('initCardInteractions — REQ-STAR-001 + REQ-READ-001 event plumbing', 
     expect(clickListeners.length).toBe(1);
     // Bubble phase, not capture (paired with stopPropagation in handler).
     expect(clickListeners[0]!.useCapture).toBe(false);
-    // Idempotency flag set on documentElement after first bind.
-    expect(dataset['starDelegationBound']).toBe('1');
+
+    // Regression for the production bug: simulate Astro's
+    // view-transition swap by replacing documentElement WHILE keeping
+    // the same document object (Astro only swaps the <html> element,
+    // not the document itself). If the idempotency flag had moved
+    // back onto documentElement.dataset, this swap would clear it and
+    // the next bindStarDelegation call would stack a second listener.
+    // The closure flag survives the swap.
+    const stubbedDoc = globalThis.document as unknown as {
+      documentElement: HTMLElement;
+    };
+    stubbedDoc.documentElement = { dataset: {} } as unknown as HTMLElement;
+    bindStarDelegation();
+    const afterSwap = calls.filter((c) => c.type === 'click');
+    expect(afterSwap.length).toBe(1);
   });
 
   it('REQ-READ-001: re-running init does not double-bind tag-triggers (dataset.bound guard)', () => {

--- a/tests/reading/card-interactions.test.ts
+++ b/tests/reading/card-interactions.test.ts
@@ -28,6 +28,7 @@ import {
   handleStarClick,
   toggleTagDisclosure,
   closeAllTagPopovers,
+  __resetForTests,
 } from '~/scripts/card-interactions';
 
 /** Minimal mock of a star <button> — only the surface the handler
@@ -343,6 +344,7 @@ describe('initCardInteractions — REQ-STAR-001 + REQ-READ-001 event plumbing', 
   });
 
   it('REQ-STAR-001: bindStarDelegation attaches exactly one document click listener and is idempotent', () => {
+    __resetForTests();
     // The whole point of the dual-handler refactor: ONE document-level
     // listener owns every star-toggle click. A double-bind would fire
     // two fetches per click (POST + DELETE) and the optimistic toggle
@@ -418,6 +420,7 @@ describe('initCardInteractions — REQ-STAR-001 + REQ-READ-001 event plumbing', 
   });
 
   it('REQ-READ-001: outside-click listener stays singleton across documentElement swap (parallel to star-delegation regression)', () => {
+    __resetForTests();
     // Counterpart to the bindStarDelegation regression test above.
     // Same view-transition swap that broke star delegation would also
     // have stacked outside-click listeners on `document` if the

--- a/tests/reading/card-interactions.test.ts
+++ b/tests/reading/card-interactions.test.ts
@@ -416,6 +416,37 @@ describe('initCardInteractions — REQ-STAR-001 + REQ-READ-001 event plumbing', 
     expect(second).toBe(0);
     expect(button.dataset['bound']).toBe('1');
   });
+
+  it('REQ-READ-001: outside-click listener stays singleton across documentElement swap (parallel to star-delegation regression)', () => {
+    // Counterpart to the bindStarDelegation regression test above.
+    // Same view-transition swap that broke star delegation would also
+    // have stacked outside-click listeners on `document` if the
+    // idempotency flag had stayed on documentElement.dataset. The
+    // closure-flag fix lives in the same module, so this test pins
+    // the second half of the bug class.
+    const calls: { type: string }[] = [];
+    vi.stubGlobal('document', {
+      documentElement: { dataset: {} } as unknown as HTMLElement,
+      addEventListener: (type: string) => {
+        calls.push({ type });
+      },
+      querySelectorAll: () => [] as unknown as NodeListOf<Element>,
+    });
+    const root = globalThis.document;
+
+    initCardInteractions(root);
+    // Simulate Astro view-transition: documentElement is replaced
+    // (its dataset is gone) but `document` itself survives. A
+    // dataset-based flag would clear and the next init call would
+    // stack a second listener on the surviving document.
+    (globalThis.document as unknown as { documentElement: HTMLElement }).documentElement = {
+      dataset: {},
+    } as unknown as HTMLElement;
+    initCardInteractions(root);
+
+    const clickListeners = calls.filter((c) => c.type === 'click');
+    expect(clickListeners.length).toBe(1);
+  });
 });
 
 describe('closeAllTagPopovers — REQ-READ-001 AC 6', () => {


### PR DESCRIPTION
## Summary

Three fixes that all land on the same surface (digest/history dashboards):

### 1. Favourites broken everywhere after first in-app navigation (the real bug)

PR #182 moved star-toggle dispatch onto a document-level click delegation but kept the idempotency flag on \`documentElement.dataset\`. Astro's default view-transition swap replaces \`documentElement\` on every cross-page navigation while preserving the \`document\` object — so the flag cleared while the listener (registered on \`document\`) survived. The \`astro:page-load\` re-bind path then stacked a second listener, and each subsequent star click dispatched POST + DELETE in parallel.

Net result the user reported: \"marking anything as favorite is now broken — everywhere... on /digest and /history.\"

Fix: move both idempotency flags (star delegation + outside-click) into module-scope closure variables. The closure outlives view-transitions, so the listener and its guard now live as one unit.

Regression test simulates the documentElement swap explicitly.

### 2. /history dashboard didn't reflect starred state

\`/api/history\` never joined \`article_stars\`, so every history card rendered as un-starred regardless of actual state. Article detail and /starred showed the correct state, but the history list did not.

Fix: add an \`EXISTS(SELECT 1 FROM article_stars ...)\` join, expose \`starred\` on \`WireArticle\`, and pass it to both \`<DigestCard>\` renders on /history (day-grouped grid + tag-filtered search grid).

### 3. Header icon misalignment + drop-cap too low

- Desktop wordmark scales to 40px but the header icon stayed 32px, so \`align-items: center\` placed the smaller icon in the visual middle of a taller text box. Bumped icon to 40px in the same media query.
- Drop-cap math assumed Charter's ascent ratio (≈0.78). Charter ships only on Apple platforms; Linux/Windows fall back to Source Serif Pro / Noto Serif / Cambria, which carry more upper padding so the cap rendered ~0.3em lower than line 1's cap-top. Added a negative \`margin-top\` to compensate.

## Test plan

- [ ] CI green (test + codeql)
- [ ] Live: hard-reload /digest, click a star → state persists
- [ ] Live: navigate /digest → /history → click a star → state persists (the regression case)
- [ ] Live: /history shows already-starred articles with the filled glyph on first render
- [ ] Live: header wordmark + icon visually aligned on desktop
- [ ] Live: drop-cap on /digest/{id}/{slug} sits with cap-top at line 1's cap-top