### PR TITLE
fix(theme): theme icon visibility CSS must be :global after CF-059

### DIFF
--- a/src/components/HeaderThemeToggle.astro
+++ b/src/components/HeaderThemeToggle.astro
@@ -55,17 +55,21 @@ import ThemeIcon from '~/components/ThemeIcon.astro';
     }
   }
 
-  .header-theme-toggle__icon {
+  /* CF-059 makes the icon <span> a child-component-rendered element;
+     Astro scopes the parent's CSS but not classes passed via props,
+     so these rules must be marked :global to match the bare class
+     names the child receives. Without this, both icons render. */
+  :global(.header-theme-toggle__icon) {
     display: none;
     line-height: 0;
   }
-  /* Light theme → show moon (click = go dark). Dark theme → show sun
+  /* Light theme = show moon (click = go dark). Dark theme = show sun
      (click = go light). Pure CSS swap keyed off the [data-theme]
      attribute on <html>. */
-  :global([data-theme='light']) .header-theme-toggle__icon--moon {
+  :global([data-theme='light'] .header-theme-toggle__icon--moon) {
     display: inline-flex;
   }
-  :global([data-theme='dark']) .header-theme-toggle__icon--sun {
+  :global([data-theme='dark'] .header-theme-toggle__icon--sun) {
     display: inline-flex;
   }
 

--- a/src/components/ThemeToggle.astro
+++ b/src/components/ThemeToggle.astro
@@ -63,16 +63,25 @@ import ThemeIcon from '~/components/ThemeIcon.astro';
     }
   }
 
-  .theme-toggle__icon {
+  /* `:global(...)` selectors are required after CF-059 because the
+     icon wrapper <span> is rendered by ThemeIcon.astro (a child
+     component), not by this file. Astro applies its scope hash only
+     to selectors and elements declared in the same component's
+     <style> block; the child component's <span> carries the bare
+     unscoped class names this parent passes via props. Without the
+     :global wrapping, the scoped rules below would never match the
+     child's DOM and both icons would render simultaneously (the bug
+     this fix repairs). */
+  :global(.theme-toggle__icon) {
     display: none;
     line-height: 0;
   }
 
   /* Show the sun in dark mode (click to go light), moon in light mode. */
-  :global([data-theme='light']) .theme-toggle__icon--moon {
+  :global([data-theme='light'] .theme-toggle__icon--moon) {
     display: inline-flex;
   }
-  :global([data-theme='dark']) .theme-toggle__icon--sun {
+  :global([data-theme='dark'] .theme-toggle__icon--sun) {
     display: inline-flex;
   }
 


### PR DESCRIPTION
Bug: dark + light theme icons render simultaneously after the Phase F10 (CF-059) extraction.

Root cause: Astro scopes component CSS by default. The CF-059 extraction moved the sun/moon SVG into a shared ThemeIcon.astro and passes class names via props. Astro can't apply its scope hash to dynamic prop class names, so the parent's scoped rules (`.theme-toggle__icon { display: none }` etc.) stop matching the child's rendered span. Both icons fall through to default display:inline.

Fix: wrap the affected selectors in `:global(...)`. One small comment block in each component documents the trap.

Test plan:
- [ ] CI green
- [ ] Live: light theme shows only moon; dark theme shows only sun
- [ ] Live: header dropdown toggle shows only the off-state glyph

skip review