### PR TITLE
fix(theme): theme icon visibility CSS must be :global after CF-059 (PR #190)

### DIFF
--- a/src/components/HeaderThemeToggle.astro
+++ b/src/components/HeaderThemeToggle.astro
@@ -55,17 +55,21 @@ import ThemeIcon from '~/components/ThemeIcon.astro';
     }
   }
 
-  .header-theme-toggle__icon {
+  /* CF-059 makes the icon <span> a child-component-rendered element;
+     Astro scopes the parent's CSS but not classes passed via props,
+     so these rules must be marked :global to match the bare class
+     names the child receives. Without this, both icons render. */
+  :global(.header-theme-toggle__icon) {
     display: none;
     line-height: 0;
   }
-  /* Light theme → show moon (click = go dark). Dark theme → show sun
+  /* Light theme = show moon (click = go dark). Dark theme = show sun
      (click = go light). Pure CSS swap keyed off the [data-theme]
      attribute on <html>. */
-  :global([data-theme='light']) .header-theme-toggle__icon--moon {
+  :global([data-theme='light'] .header-theme-toggle__icon--moon) {
     display: inline-flex;
   }
-  :global([data-theme='dark']) .header-theme-toggle__icon--sun {
+  :global([data-theme='dark'] .header-theme-toggle__icon--sun) {
     display: inline-flex;
   }
 

--- a/src/components/ThemeToggle.astro
+++ b/src/components/ThemeToggle.astro
@@ -63,16 +63,25 @@ import ThemeIcon from '~/components/ThemeIcon.astro';
     }
   }
 
-  .theme-toggle__icon {
+  /* `:global(...)` selectors are required after CF-059 because the
+     icon wrapper <span> is rendered by ThemeIcon.astro (a child
+     component), not by this file. Astro applies its scope hash only
+     to selectors and elements declared in the same component's
+     <style> block; the child component's <span> carries the bare
+     unscoped class names this parent passes via props. Without the
+     :global wrapping, the scoped rules below would never match the
+     child's DOM and both icons would render simultaneously (the bug
+     this fix repairs). */
+  :global(.theme-toggle__icon) {
     display: none;
     line-height: 0;
   }
 
   /* Show the sun in dark mode (click to go light), moon in light mode. */
-  :global([data-theme='light']) .theme-toggle__icon--moon {
+  :global([data-theme='light'] .theme-toggle__icon--moon) {
     display: inline-flex;
   }
-  :global([data-theme='dark']) .theme-toggle__icon--sun {
+  :global([data-theme='dark'] .theme-toggle__icon--sun) {
     display: inline-flex;
   }
 


### PR DESCRIPTION
Promotes 3a752aa from develop to main. Hot-fix for production: dark and light theme icons rendered simultaneously after the CF-059 ThemeIcon extraction. Astro scopes parent CSS but not prop-passed class names; :global wrapping restores the visibility toggle.

skip review