### PR TITLE
fix(pipeline): recover article ingestion + per-tag Google News baseline

### DIFF
--- a/documentation/architecture.md
+++ b/documentation/architecture.md
@@ -115,7 +115,7 @@ Every source file annotates the REQ-IDs it implements via `// Implements REQ-X-N
 | `sources.ts` | Source adapters (RSS/Atom/JSON) and fan-out coordinator | [REQ-PIPE-001](../sdd/generation.md#req-pipe-001-global-scrape-and-summarise-pipeline-on-a-fixed-cadence) |
 | `prefer-direct-source.ts` | Resolve aggregator URLs (e.g., Google News) to underlying publisher and merge tag-of-discovery state | [REQ-PIPE-001](../sdd/generation.md#req-pipe-001-global-scrape-and-summarise-pipeline-on-a-fixed-cadence), [REQ-PIPE-003](../sdd/generation.md#req-pipe-003-canonical-url--llm-cluster-dedupe-with-first-source-wins) |
 | `paragraph-split.ts` | Normalise LLM-produced prose into a paragraph array for the article-detail view | [REQ-READ-002](../sdd/reading.md#req-read-002-article-detail-view) |
-| `curated-sources.ts` | Static registry of curated feeds | [REQ-PIPE-004](../sdd/generation.md#req-pipe-004-curated-source-registry-with-50-feeds-spanning-the-21-system-tags) |
+| `curated-sources.ts` | Static registry of curated feeds; exports `googleNewsSourceForTag` (per-tag GN query-RSS synthesis) and `hasCuratedGoogleNews` (skip-guard for the coordinator baseline pass) | [REQ-PIPE-004](../sdd/generation.md#req-pipe-004-curated-source-registry-with-50-feeds-spanning-the-21-system-tags), [REQ-PIPE-001](../sdd/generation.md#req-pipe-001-global-scrape-and-summarise-pipeline-on-a-fixed-cadence) AC 9 |
 | `dedupe.ts` | Canonical-URL plus LLM-cluster dedup; first-source-wins | [REQ-PIPE-003](../sdd/generation.md#req-pipe-003-canonical-url--llm-cluster-dedupe-with-first-source-wins) |
 | `finalize-merge.ts` | Pure helpers for the finalize pass (cross-chunk semantic dedup) | [REQ-PIPE-008](../sdd/generation.md#req-pipe-008-cross-chunk-semantic-dedup-pass) |
 | `scrape-run.ts` | `scrape_runs` lifecycle helpers (`running` → `ready` / `failed`) | [REQ-PIPE-001](../sdd/generation.md#req-pipe-001-global-scrape-and-summarise-pipeline-on-a-fixed-cadence), [REQ-PIPE-006](../sdd/generation.md#req-pipe-006-scrape_runs-aggregation-surfaces-stats-history-and-in-flight-progress) |
@@ -181,7 +181,7 @@ Page components (`src/pages/*.astro`) and API handlers (`src/pages/api/**.ts`) �
 | Path | Role | Implements |
 |---|---|---|
 | `src/worker.ts` | Cron + queue dispatch entry — three cron branches, four queue message types | [REQ-PIPE-001](../sdd/generation.md#req-pipe-001-global-scrape-and-summarise-pipeline-on-a-fixed-cadence), [REQ-PIPE-005](../sdd/generation.md#req-pipe-005-fourteen-day-retention-with-starred-exempt-cleanup), [REQ-MAIL-001](../sdd/email.md#req-mail-001-digest-ready-email) |
-| `src/queue/scrape-coordinator.ts` | Fan-out, freshness filter, eviction pass, multi-source aggregation on re-discovery, chunk dispatch | [REQ-PIPE-001](../sdd/generation.md#req-pipe-001-global-scrape-and-summarise-pipeline-on-a-fixed-cadence), [REQ-DISC-003](../sdd/discovery.md#req-disc-003-self-healing-feed-health-tracking) |
+| `src/queue/scrape-coordinator.ts` | Fan-out, freshness filter, eviction pass, multi-source aggregation on re-discovery, per-tag Google News baseline synthesis (REQ-PIPE-001 AC 9), chunk dispatch | [REQ-PIPE-001](../sdd/generation.md#req-pipe-001-global-scrape-and-summarise-pipeline-on-a-fixed-cadence), [REQ-DISC-003](../sdd/discovery.md#req-disc-003-self-healing-feed-health-tracking) |
 | `src/queue/scrape-chunk-consumer.ts` | Per-chunk LLM call, dedup, atomic completion gate, finalize handoff | [REQ-PIPE-002](../sdd/generation.md#req-pipe-002-chunked-llm-processing-with-json-output-contract), [REQ-PIPE-008](../sdd/generation.md#req-pipe-008-cross-chunk-semantic-dedup-pass) |
 | `src/queue/scrape-finalize-consumer.ts` | Finalize pass (cross-chunk semantic dedup) — LLM prompt uses title + full article body; source name dropped as non-signal. Upfront SELECT short-circuits redelivery before the LLM call when `finalize_recorded` is already set. Cost recorded atomically via `finalize_recorded` gate (migration 0010) regardless of merge count | [REQ-PIPE-008](../sdd/generation.md#req-pipe-008-cross-chunk-semantic-dedup-pass) |
 | `src/queue/cleanup.ts` | Daily 3-pass cleanup: retention, stuck-tag prune, orphan-tag KV sweep | [REQ-PIPE-005](../sdd/generation.md#req-pipe-005-fourteen-day-retention-with-starred-exempt-cleanup), [REQ-DISC-006](../sdd/discovery.md#req-disc-006-stuck-tag-retention), [REQ-PIPE-007](../sdd/generation.md#req-pipe-007-orphan-tag-source-cleanup) |
@@ -207,6 +207,9 @@ Cron (00/04/08/12/16/20 UTC)
        │
        ▼
 Coordinator
+  ├─ Synthesise per-tag Google News query-RSS source for every tag in
+  │  (default-seed ∪ curated ∪ discovered KV); skip tags with a bespoke
+  │  hand-tuned GN curated entry (REQ-PIPE-001 AC 9)
   ├─ Fan out {tag × source} pairs (concurrency 10)
   ├─ Record per-URL fetch outcome → KV source_health:{url}
   ├─ Evict URLs at 30 consecutive failures; re-queue discovery if feed list empties

--- a/sdd/.review-needed.md
+++ b/sdd/.review-needed.md
@@ -10,3 +10,27 @@ Findings escalated by spec-reviewer or doc-updater that require human attention.
   - **Architecture ASCII diagrams over the 15-line per-element cap** — annotated inline in `documentation/architecture.md` with `<!-- doc-allow-large -->` markers above each fenced diagram. Diagrams kept as-is.
 
 - JUDGMENT resolutions go in ADRs (`documentation/decisions/`), not `sdd/.user-overrides.md`. The override file is deprecated by [codeflare#266](https://github.com/nikolanovoselec/codeflare/issues/266); spec-reviewer reads each ADR's `Overrides:` header to honour skips.
+
+## 2026-05-05 — fix/article-yield-recovery PR review
+
+### MEDIUM — Two parallel Google News paths now exist; ownership is unclear
+
+Two independent code paths now produce a Google News query-RSS source for the same tag:
+
+1. **Discovery-LLM path** (REQ-DISC-001 AC 3): for tags without a curated source, the LLM-discovery prompt instructs the model to include a Google News fallback URL, which is validated and persisted to KV `sources:{tag}` with no TTL. This is per-tag, written once at discovery time.
+2. **Coordinator-baseline path** (new REQ-PIPE-001 AC 9): every tick, the coordinator synthesises a per-tag GN query-RSS source for every tag in (defaults ∪ curated ∪ discovered KV). The skip set is bespoke `google-news-*` curated entries only — it does NOT skip tags whose KV `sources:{tag}` already contains a GN URL written by the discovery LLM.
+
+Net effect: a discovered non-curated tag without a first-party feed will fan out a GN query twice per tick (once via the KV-cached discovery URL, once via coordinator synthesis). The query strings differ slightly (LLM-crafted vs. tag-with-dashes-as-spaces), so canonical-URL dedup may not catch every overlap; the prefer-direct-source pass cleans up downstream but only when a direct copy lands in the same tick.
+
+This is not a spec conflict — both ACs read correctly and describe distinct mechanisms. But it is an **unresolved architectural question**:
+
+- Should REQ-DISC-001 AC 3 drop the GN fallback now that REQ-PIPE-001 AC 9 provides per-tag GN baseline at the coordinator? The discovery LLM could focus solely on first-party sources, and the coordinator owns GN entirely.
+- Or should REQ-PIPE-001 AC 9's skip set widen to cover tags whose KV cache already contains any GN URL?
+
+Resolution path: record an ADR in `documentation/decisions/` (likely titled "Google News baseline lives at the coordinator, not in discovery") that picks one ownership model. Until then both paths coexist with mild redundancy that the dedup pass mostly absorbs.
+
+### LOW — New `googleNewsSourceForTag` tests do not name a REQ ID
+
+The unit tests added in `tests/pipeline/curated-sources.test.ts` for `googleNewsSourceForTag` and `hasCuratedGoogleNews` live under a new `describe('googleNewsSourceForTag — auto-synthesised per-tag GN feeds', …)` block. Neither the describe nor the individual `it(...)` strings reference a REQ ID. The function implements REQ-PIPE-001 AC 9 (or arguably extends REQ-PIPE-004), so spec-reviewer's substring REQ-grep over test files will not pick these up as covering the new AC.
+
+Suggested fix in a follow-up commit: rename the describe to `googleNewsSourceForTag — REQ-PIPE-001 AC 9` (or add `REQ-PIPE-001:` prefixes to each `it(...)` string) so the source-vs-test coverage check sees the link.

--- a/sdd/changes.md
+++ b/sdd/changes.md
@@ -8,6 +8,8 @@ Entries from 2026-04-22 through 2026-04-26 (the global-feed rework window) are a
 
 ## 2026-05-05
 
+- REQ-PIPE-002 AC 3 recalibrated: the chunk consumer's word-count backstop drops from 120 to 80 words. The 120-word floor (added 2026-05-03) cut off ~80% of the model's natural output distribution and dropped daily ingestion from ~100 to ~25 articles; the prompt's contract remains 150-200 words but the server-side floor now only catches genuinely truncated stubs rather than the model's lower-end natural range.
+- REQ-PIPE-001 AC extended: the coordinator now synthesises a per-tag Google News query-RSS source for every tag in the union of (default hashtags ∪ curated tags ∪ discovered KV tags) that does NOT already have a bespoke `google-news-*` curated entry. Wide GN fan-out is safe because `prefer-direct-source` already drops a Google News headline whose title overlaps a direct publisher copy in the same tick — so every tag now has a long-tail backstop without polluting the dedup pool.
 - REQ-AUTH-005 AC 3 corrected: account deletion clears both session cookies (access and refresh), matching the logout contract in REQ-AUTH-002 AC 3 — previously the AC named only "the session cookie" in the singular, which understated the actual cookie-clear behavior.
 - REQ-PIPE-001 AC8 reworded: "coordinator fetches the article body" changed to "pipeline fetches the article body" — the chunk consumer, not the coordinator, performs the body-fetch step; the AC now names the actor correctly without changing the observable contract.
 - REQ-OPS-003 AC1 reworded: the CSP requirement now uses user-observable language ("restricts script execution to same-origin, blocks inline event handlers") with the literal directive value moved to documentation/security.md.

--- a/sdd/generation.md
+++ b/sdd/generation.md
@@ -24,6 +24,7 @@ A global scrape-and-summarise pipeline that runs every 4 hours: one cron-trigger
    c. Readable plaintext is extracted and attached to the candidate.
    d. When extraction yields too little text, the candidate falls back to whatever the feed itself provided.
    e. A failed body-fetch never blocks a summary.
+9. Every tag in the union of (default-seed hashtags ∪ curated source tags ∪ discovered KV tags) gets a per-tag Google News query-RSS source added to the tick's source list as a long-tail backstop. Tags already served by a bespoke hand-tuned Google News curated entry are skipped (no double-fetch). The aggregator-vs-direct dedup pass already prefers a direct publisher copy over a Google News copy that lands in the same tick, so wide GN fan-out gives every tag baseline coverage without polluting the article pool with aggregator duplicates when direct sources also surface the story.
 
 **Constraints:** CON-LLM-001, CON-PERF-001, CON-SEC-002
 **Priority:** P0
@@ -42,7 +43,7 @@ A global scrape-and-summarise pipeline that runs every 4 hours: one cron-trigger
 **Acceptance Criteria:**
 1. Each chunk yields a JSON payload shaped `{articles: [{title, details[], tags[]}], dedup_groups: [[…]]}` and no other top-level keys.
 2. Titles are NYT-style headlines, 45–80 characters, active voice, rewritten rather than copied from the source feed. The 45–80 range is the prompt-side target; the consumer additionally enforces a hard sanity range of 5–500 characters server-side, dropping titles outside that range so genuinely broken cases (single-character labels, paragraph-as-title) never reach the reading surface.
-3. `details` is a plaintext body of 150–200 words split into 2 or 3 paragraphs (WHAT happened, HOW it works, and optionally IMPACT for the reader), each 3–5 sentences, with no lists, HTML, or Markdown. Responses under ~120 words are treated as malformed and dropped server-side, so a model that ignores the word-count instruction cannot ship a truncated body as a real article.
+3. `details` is a plaintext body of 150–200 words split into 2 or 3 paragraphs (WHAT happened, HOW it works, and optionally IMPACT for the reader), each 3–5 sentences, with no lists, HTML, or Markdown. The 150–200 range is the prompt-side contract; the consumer additionally enforces an 80-word backstop server-side, dropping responses below that threshold so a model that ships a single-sentence stub cannot reach the reading surface. The backstop is a true sanity floor (genuinely truncated outputs), not the model's normal operating range.
 4. `tags` values come exclusively from the system-approved allowlist — the union of the default-seed hashtag list shared with new accounts plus every tag for which a discovered-source cache currently exists. Any tag the LLM invents outside that union is discarded server-side before persistence, and an article that ends up with zero valid tags is dropped.
 5. Intra-chunk duplicates collapse via the `dedup_groups` hints: the earliest-published source becomes the primary article and the others are recorded as alternative sources.
 6. A chunk failure marks only that chunk's portion of the run as failed; other chunks in the same tick still persist their articles.

--- a/src/lib/curated-sources.ts
+++ b/src/lib/curated-sources.ts
@@ -1,4 +1,4 @@
-// Implements REQ-PIPE-004, REQ-DISC-001
+// Implements REQ-PIPE-001, REQ-PIPE-004, REQ-DISC-001
 //
 // Curated feed registry for the global-feed scrape pipeline. Each entry is
 // a trusted HTTPS feed (RSS, Atom, or JSON Feed) that the scrape coordinator
@@ -15,6 +15,8 @@
 // Live-fetch validation is deliberately NOT automated — the dev script
 // `scripts/validate-curated-sources.mjs` probes each URL with a real fetch
 // and prints a swap-list for feeds that 4xx/5xx. Run it before every deploy.
+
+import { HASHTAG_REGEX } from './hashtags';
 
 /** Feed format. We parse RSS 2.0 and Atom the same way (fast-xml-parser);
  * `json` is reserved for JSON Feed 1.1 endpoints. */
@@ -564,7 +566,12 @@ export function hasCuratedGoogleNews(tag: string): boolean {
  */
 export function googleNewsSourceForTag(tag: string): CuratedSource | null {
   if (tag === '' || hasCuratedGoogleNews(tag)) return null;
-  if (!/^[a-z0-9-]+$/.test(tag)) return null;
+  // Reuse the canonical hashtag shape (2-32 chars, lowercase letters /
+  // digits / dashes) so this helper stays in lockstep with the
+  // user-facing tag validator. Permissive-regex drift here would let a
+  // malformed tag from a future call site reach Google News as a
+  // bogus query.
+  if (!HASHTAG_REGEX.test(tag)) return null;
   const q = encodeURIComponent(tag.replace(/-/g, ' '));
   return {
     slug: `google-news-auto-${tag}`,

--- a/src/lib/curated-sources.ts
+++ b/src/lib/curated-sources.ts
@@ -526,3 +526,51 @@ const CURATED_TAGS: ReadonlySet<string> = new Set(
 export function hasCuratedSource(tag: string): boolean {
   return CURATED_TAGS.has(tag);
 }
+
+/**
+ * Set of tags already served by a bespoke `google-news-*` curated entry.
+ * Auto-synthesised generic GN sources skip these tags so the bespoke
+ * (more precise) query is the only Google News call for that tag.
+ */
+const GOOGLE_NEWS_CURATED_TAGS: ReadonlySet<string> = new Set(
+  CURATED_SOURCES
+    .filter((s) => s.slug.startsWith('google-news-'))
+    .flatMap((s) => s.tags),
+);
+
+/**
+ * True iff a bespoke `google-news-*` curated entry already covers
+ * {@link tag}. Used by {@link googleNewsSourceForTag} to skip
+ * auto-synthesis for tags that already have a hand-tuned GN query
+ * (avoids two redundant fetches per tick for the same Google News
+ * results).
+ */
+export function hasCuratedGoogleNews(tag: string): boolean {
+  return GOOGLE_NEWS_CURATED_TAGS.has(tag);
+}
+
+/**
+ * Build a synthetic curated source that fetches Google News query-RSS
+ * for {@link tag}. Returns `null` when {@link tag} is empty, malformed,
+ * or already covered by a bespoke `google-news-*` curated entry.
+ *
+ * The query is the tag with dashes converted to spaces (e.g.
+ * `supply-chain-security` → `supply chain security`), URL-encoded.
+ * That's a deliberately simple query: tags are short and topical, so
+ * the natural English phrasing produces the most relevant Google News
+ * coverage. `prefer-direct-source.ts` drops the GN copy when a direct
+ * publisher copy lands in the same tick (≥3 shared title tokens), so
+ * a generous GN fan-out costs nothing on the dedup side.
+ */
+export function googleNewsSourceForTag(tag: string): CuratedSource | null {
+  if (tag === '' || hasCuratedGoogleNews(tag)) return null;
+  if (!/^[a-z0-9-]+$/.test(tag)) return null;
+  const q = encodeURIComponent(tag.replace(/-/g, ' '));
+  return {
+    slug: `google-news-auto-${tag}`,
+    name: `Google News: ${tag}`,
+    feed_url: `https://news.google.com/rss/search?q=${q}&hl=en-US&gl=US&ceid=US:en`,
+    kind: 'rss',
+    tags: [tag],
+  };
+}

--- a/src/lib/prompts.ts
+++ b/src/lib/prompts.ts
@@ -101,10 +101,17 @@ Shape:
 
 # DETAILS RULES — THIS IS THE CORE TASK
 
-LENGTH — 150 to 200 WORDS:
+LENGTH — 150 to 200 WORDS (NON-NEGOTIABLE CONTRACT):
 
-  - Minimum 150 words. Under 120 words is malformed and will be dropped.
-  - Maximum 200 words. Do not pad or repeat.
+  - The summary MUST be 150-200 words. This is the contract; do not
+    ship under 150. If the snippet feels thin, extend the WHAT and
+    HOW paragraphs with concrete grounded facts — never pad with
+    filler, never repeat, but never cut short either.
+  - Maximum 200 words. Do not exceed.
+  - The server enforces an 80-word backstop and rejects anything
+    shorter as malformed. Your TARGET is 150-200, not 80 — the
+    backstop catches obviously broken output, not your normal
+    operating range.
 
 STRUCTURE — 2 to 3 PARAGRAPHS:
 

--- a/src/lib/prompts.ts
+++ b/src/lib/prompts.ts
@@ -108,10 +108,8 @@ LENGTH — 150 to 200 WORDS (NON-NEGOTIABLE CONTRACT):
     HOW paragraphs with concrete grounded facts — never pad with
     filler, never repeat, but never cut short either.
   - Maximum 200 words. Do not exceed.
-  - The server enforces an 80-word backstop and rejects anything
-    shorter as malformed. Your TARGET is 150-200, not 80 — the
-    backstop catches obviously broken output, not your normal
-    operating range.
+  - Truncated outputs are rejected server-side as malformed. Your
+    target is 150-200; aim for the middle of that range.
 
 STRUCTURE — 2 to 3 PARAGRAPHS:
 

--- a/src/queue/scrape-chunk-consumer.ts
+++ b/src/queue/scrape-chunk-consumer.ts
@@ -559,9 +559,17 @@ function validateAndSanitizeArticle(
     .filter((p) => p !== '');
   if (title === '' || details.length === 0) return null;
 
-  // REQ-PIPE-002 AC3: enforce 120-word floor server-side.
+  // REQ-PIPE-002 AC3: enforce 80-word backstop floor server-side. The
+  // prompt's contract is 150-200 words; the floor catches genuinely
+  // truncated outputs (single-paragraph 30-word stubs) without
+  // rejecting the model's natural lower-end distribution. CF-030
+  // originally set this to 120 but Workers AI gpt-oss-120b regularly
+  // produces 100-130-word summaries when the source snippet is thin,
+  // so 120 cut off ~80% of the legitimate output and dropped daily
+  // ingestion from ~100 to ~25 articles. 80 is a true sanity floor;
+  // the 150-word target stays in the prompt as the contract.
   const wordCount = details.join(' ').trim().split(/\s+/).filter((w) => w !== '').length;
-  if (wordCount < 120) {
+  if (wordCount < 80) {
     log('warn', 'digest.generation', {
       status: 'chunk_article_dropped_word_count',
       scrape_run_id: body.scrape_run_id,

--- a/src/queue/scrape-coordinator.ts
+++ b/src/queue/scrape-coordinator.ts
@@ -20,9 +20,11 @@
 
 import {
   CURATED_SOURCES,
+  googleNewsSourceForTag,
   hasCuratedSource,
   type CuratedSource,
 } from '~/lib/curated-sources';
+import { DEFAULT_HASHTAGS } from '~/lib/default-hashtags';
 import {
   adaptersForDiscoveredFeeds,
   fetchFromSourceWithResult,
@@ -284,6 +286,29 @@ async function assembleAllSources(env: Env): Promise<SourceForFetch[]> {
         'KV scan failed mid-iteration; some discovered tags may be missing from this tick.',
     });
   }
+  // Synthesise per-tag Google News query-RSS sources for every tag in
+  // (DEFAULT_HASHTAGS ∪ curated tags ∪ discovered KV tags) that does
+  // NOT already have a bespoke `google-news-*` curated entry. The
+  // post-canonical-dedup pass in `prefer-direct-source.ts` drops the
+  // GN copy when a direct publisher copy lands in the same tick, so
+  // wide GN fan-out is safe and gives every tag a long-tail backstop.
+  const allTags = new Set<string>();
+  for (const t of DEFAULT_HASHTAGS) allTags.add(t);
+  for (const s of CURATED_SOURCES) for (const t of s.tags) allTags.add(t);
+  for (const ds of discoveredSources) {
+    if (ds.discoveredTag !== null) allTags.add(ds.discoveredTag);
+  }
+  const googleNewsSources: SourceForFetch[] = [];
+  for (const tag of allTags) {
+    const synth = googleNewsSourceForTag(tag);
+    if (synth === null) continue;
+    googleNewsSources.push({
+      adapter: curatedToAdapter(synth),
+      sourceName: synth.name,
+      feedUrl: synth.feed_url,
+      discoveredTag: null,
+    });
+  }
   return [
     ...CURATED_SOURCES.map((s) => ({
       adapter: curatedToAdapter(s),
@@ -292,6 +317,7 @@ async function assembleAllSources(env: Env): Promise<SourceForFetch[]> {
       discoveredTag: null as string | null,
     })),
     ...discoveredSources,
+    ...googleNewsSources,
   ];
 }
 

--- a/src/queue/scrape-coordinator.ts
+++ b/src/queue/scrape-coordinator.ts
@@ -286,12 +286,24 @@ async function assembleAllSources(env: Env): Promise<SourceForFetch[]> {
         'KV scan failed mid-iteration; some discovered tags may be missing from this tick.',
     });
   }
-  // Synthesise per-tag Google News query-RSS sources for every tag in
-  // (DEFAULT_HASHTAGS ∪ curated tags ∪ discovered KV tags) that does
-  // NOT already have a bespoke `google-news-*` curated entry. The
-  // post-canonical-dedup pass in `prefer-direct-source.ts` drops the
-  // GN copy when a direct publisher copy lands in the same tick, so
-  // wide GN fan-out is safe and gives every tag a long-tail backstop.
+  // Synthesise per-tag Google News query-RSS sources. Collect every
+  // candidate tag (DEFAULT_HASHTAGS ∪ all curated tags ∪ discovered KV
+  // tags) into one set, then `googleNewsSourceForTag` filters out tags
+  // already covered by a bespoke `google-news-*` curated entry — one
+  // pass through the helper handles dedup so the loop body stays
+  // simple. The post-canonical-dedup pass in `prefer-direct-source.ts`
+  // drops the GN copy when a direct publisher copy lands in the same
+  // tick, so wide GN fan-out is safe and gives every tag a long-tail
+  // backstop.
+  //
+  // `discoveredTag: null` is intentional even though the synth source
+  // is conceptually "for" a tag: GN URLs are infrastructure-grade and
+  // shouldn't be subject to per-tag eviction (the eviction path
+  // permanently removes a feed from `sources:{tag}` after a failure
+  // streak). A transient GN outage shouldn't disable GN for one tag
+  // forever, so we opt OUT of health tracking by keeping the tag null.
+  // The synth feed is rebuilt every tick from `googleNewsSourceForTag`
+  // so it self-heals when GN recovers.
   const allTags = new Set<string>();
   for (const t of DEFAULT_HASHTAGS) allTags.add(t);
   for (const s of CURATED_SOURCES) for (const t of s.tags) allTags.add(t);

--- a/tests/pipeline/chunk-consumer.test.ts
+++ b/tests/pipeline/chunk-consumer.test.ts
@@ -905,15 +905,16 @@ describe('scrape-chunk-consumer — REQ-PIPE-002', () => {
     }
   });
 
-  it('REQ-PIPE-002 AC3 / CF-030: drops articles whose details word count falls under the 120-word floor', async () => {
-    // The prompt itself flags responses under ~120 words as malformed.
-    // Without a server-side guard a model that ignores the contract
-    // can still ship a 30-word stub as a real article. A passing
-    // sibling article in the same chunk proves only the malformed
-    // entry is dropped, not the whole batch.
+  it('REQ-PIPE-002 AC3: drops articles whose details word count falls under the 80-word backstop floor', async () => {
+    // The prompt's contract is 150-200 words; the server enforces an
+    // 80-word backstop so genuinely truncated outputs (single-paragraph
+    // 30-word stubs) get dropped without rejecting the model's natural
+    // 100-130 lower-end distribution. A passing sibling article in the
+    // same chunk proves only the malformed entry is dropped, not the
+    // whole batch.
     const tooShort = 'Short body sentence one. Sentence two. Sentence three.';
     const longBody =
-      'This is a long-enough article body that easily clears the 120-word floor. '
+      'This is a long-enough article body that easily clears the 80-word floor. '
         .repeat(14) +
       'It crosses two paragraph boundaries with explicit periods between sentences.';
     const aiResponse = {
@@ -938,6 +939,40 @@ describe('scrape-chunk-consumer — REQ-PIPE-002', () => {
     expect(articleInserts.length).toBe(1);
     expect(articleInserts[0]!.params).toContain('Title A — long enough headline copy');
     expect(articleInserts[0]!.params).not.toContain('Title B — also long enough headline');
+  });
+
+  it('REQ-PIPE-002 AC3: keeps articles in the 80-150 natural-distribution range that the prompt asks for but the model often undershoots', async () => {
+    // The Workers AI gpt-oss-120b often produces 100-130-word summaries
+    // when source snippets are thin. The 80-word floor is a backstop,
+    // not a contract — bodies above 80 must pass. Pinning the boundary
+    // here so a future tightening (back to 120) is caught by CI rather
+    // than discovered via a 75% drop in daily ingestion.
+    const exactly100Words = Array.from({ length: 100 }, (_, i) => `word${i}`).join(' ');
+    const aiResponse = {
+      response: JSON.stringify({
+        articles: [
+          {
+            index: 0,
+            title: 'A natural-distribution-length headline that fits in range',
+            details: exactly100Words,
+            tags: ['cloudflare'],
+          },
+        ],
+        dedup_groups: [],
+      }),
+      usage: { input_tokens: 10, output_tokens: 10 },
+    };
+    const { db, records } = makeDb();
+    const { kv } = makeKv({ chunksRemaining: '1' });
+    const env = makeEnv(db, kv, aiResponse);
+    await processOneChunk(env, makeChunk());
+    const articleInserts = records.filter(
+      (r) =>
+        r.via === 'batch' &&
+        r.sql.startsWith('INSERT OR IGNORE INTO articles'),
+    );
+    expect(articleInserts.length).toBe(1);
+    expect(articleInserts[0]!.params).toContain('A natural-distribution-length headline that fits in range');
   });
 
   it('REQ-PIPE-002 AC2 / CF-030: drops articles whose title length is outside the [5, 500] sanity range', async () => {

--- a/tests/pipeline/curated-sources.test.ts
+++ b/tests/pipeline/curated-sources.test.ts
@@ -9,7 +9,11 @@
 //   - unique slugs so cache keys and log fields stay collision-free
 
 import { describe, it, expect } from 'vitest';
-import { CURATED_SOURCES } from '~/lib/curated-sources';
+import {
+  CURATED_SOURCES,
+  googleNewsSourceForTag,
+  hasCuratedGoogleNews,
+} from '~/lib/curated-sources';
 import { DEFAULT_HASHTAGS } from '~/lib/default-hashtags';
 
 describe('curated-sources — REQ-PIPE-004', () => {
@@ -67,6 +71,67 @@ describe('curated-sources — REQ-PIPE-004', () => {
     for (const source of CURATED_SOURCES) {
       expect(source.name.length).toBeGreaterThan(0);
       expect(source.name).toBe(source.name.trim());
+    }
+  });
+});
+
+describe('googleNewsSourceForTag — auto-synthesised per-tag GN feeds', () => {
+  it('builds a Google News query-RSS source for an uncovered tag with dashes converted to spaces and URL-encoded', () => {
+    const synth = googleNewsSourceForTag('supply-chain-security');
+    expect(synth).not.toBeNull();
+    expect(synth!.slug).toBe('google-news-auto-supply-chain-security');
+    expect(synth!.name).toBe('Google News: supply-chain-security');
+    expect(synth!.kind).toBe('rss');
+    expect(synth!.tags).toEqual(['supply-chain-security']);
+    // Dashes become spaces in the query, then URL-encoded as `+` or `%20`.
+    expect(synth!.feed_url).toContain('q=supply%20chain%20security');
+    expect(synth!.feed_url.startsWith('https://news.google.com/rss/search?')).toBe(true);
+  });
+
+  it('returns null for tags already served by a bespoke `google-news-*` curated entry', () => {
+    // anthropic-ish tags are covered by `google-news-anthropic` (tags:
+    // ['ai-agents','generative-ai']). pqc by `google-news-pqc`.
+    expect(googleNewsSourceForTag('ai-agents')).toBeNull();
+    expect(googleNewsSourceForTag('generative-ai')).toBeNull();
+    expect(googleNewsSourceForTag('pqc')).toBeNull();
+    expect(googleNewsSourceForTag('coding-agents')).toBeNull();
+    expect(googleNewsSourceForTag('openziti')).toBeNull();
+  });
+
+  it('returns null for empty / malformed tag input (defence against KV corruption)', () => {
+    expect(googleNewsSourceForTag('')).toBeNull();
+    expect(googleNewsSourceForTag('Has Spaces')).toBeNull();
+    expect(googleNewsSourceForTag('UPPERCASE')).toBeNull();
+    expect(googleNewsSourceForTag('with/slash')).toBeNull();
+    expect(googleNewsSourceForTag('quote"injection')).toBeNull();
+  });
+
+  it('hasCuratedGoogleNews mirrors the bespoke `google-news-*` tag set derived from CURATED_SOURCES', () => {
+    // Derive ground truth from the same registry the production helper
+    // reads — fails if a future curated entry adds GN coverage for a
+    // new tag without the helper picking it up.
+    const expected = new Set(
+      CURATED_SOURCES
+        .filter((s) => s.slug.startsWith('google-news-'))
+        .flatMap((s) => s.tags),
+    );
+    for (const tag of expected) {
+      expect(hasCuratedGoogleNews(tag)).toBe(true);
+    }
+    // Every DEFAULT tag NOT in `expected` must NOT be flagged as covered.
+    for (const tag of DEFAULT_HASHTAGS) {
+      if (!expected.has(tag)) {
+        expect(hasCuratedGoogleNews(tag)).toBe(false);
+      }
+    }
+  });
+
+  it('every DEFAULT_HASHTAGS tag is either bespoke-GN-covered OR auto-synthesisable (no tag falls through both)', () => {
+    for (const tag of DEFAULT_HASHTAGS) {
+      const covered = hasCuratedGoogleNews(tag);
+      const synth = googleNewsSourceForTag(tag);
+      // Exactly one of: covered by bespoke entry, OR a synth source builds.
+      expect(covered === (synth === null)).toBe(true);
     }
   });
 });

--- a/tests/pipeline/curated-sources.test.ts
+++ b/tests/pipeline/curated-sources.test.ts
@@ -127,11 +127,18 @@ describe('googleNewsSourceForTag — auto-synthesised per-tag GN feeds', () => {
   });
 
   it('every DEFAULT_HASHTAGS tag is either bespoke-GN-covered OR auto-synthesisable (no tag falls through both)', () => {
+    // Exactly one of (a) covered by a bespoke `google-news-*` curated
+    // entry, or (b) a synth source is built. Two named branches read
+    // more clearly on failure than an XOR boolean would.
     for (const tag of DEFAULT_HASHTAGS) {
       const covered = hasCuratedGoogleNews(tag);
       const synth = googleNewsSourceForTag(tag);
-      // Exactly one of: covered by bespoke entry, OR a synth source builds.
-      expect(covered === (synth === null)).toBe(true);
+      if (covered) {
+        expect(synth).toBeNull();
+      } else {
+        expect(synth).not.toBeNull();
+        expect(synth!.tags).toContain(tag);
+      }
     }
   });
 });


### PR DESCRIPTION
## Summary

Daily article ingestion dropped from ~100/day to ~25/day starting 2026-05-04 — a 75% drop traced to PR #169 (CF-030, merged 2026-05-03 ~23:30Z) which added a 120-word server-side floor on `details`. The Workers AI gpt-oss-120b model regularly produces 100-130 words when source snippets are thin, so the floor cut off most of the natural output distribution.

Three changes restore yield:

- **Word-count backstop floor 120 → 80** in `src/queue/scrape-chunk-consumer.ts`. Catches genuinely-truncated stubs without rejecting the natural 100-130 distribution. Regression-pinned with a 100-word test.
- **Prompt rewritten** with NON-NEGOTIABLE CONTRACT framing in `src/lib/prompts.ts` — 150-200 words is the contract; the 80-word backstop is described as a malformed guard, not the target.
- **Per-tag Google News baseline** in `src/queue/scrape-coordinator.ts` and `src/lib/curated-sources.ts`. The coordinator synthesises a Google News query-RSS source for every tag in (DEFAULT_HASHTAGS ∪ curated tags ∪ discovered KV tags) that does NOT already have a bespoke `google-news-*` curated entry. Safe because `prefer-direct-source.ts` already drops a GN headline whose title shares ≥3 tokens with a direct publisher copy.

REQ-PIPE-002 AC 3 recalibration and REQ-PIPE-001 source-list extension captured in `sdd/changes.md`.

## Evidence

DB query against production (`articles.ingested_at`):
- 2026-04-25 to 2026-05-03: avg ~100 articles/day, peak 150
- 2026-05-04 to 2026-05-05: 24 + 31 articles
- `articles_deduped` per scrape_run jumped from ~30 to ~60 (the LLM-output-rejected count, of which the word-floor was the dominant cause)
- accepted articles cluster at 122-200 words — the minimum hugs the 120 floor exactly, confirming the diagnosis

## Test plan

- [ ] CI green (vitest unit, type checking, lint)
- [ ] Workers AI deploy reaches Cloudflare and the next coordinator tick (every 4h) ingests ≥30 articles
- [ ] `wrangler tail` shows `chunk_article_dropped_word_count` warnings dropping in volume
- [ ] After 24h, daily article count returns to ~80-150 baseline
- [ ] Top sources list resumes showing first-party feeds (CachyOS, PyPI, Azure SDK, Rust Users) alongside Google News for every tag