### PR TITLE
fix(digest): alt_source_count must exclude primary URL to match modal filter

### DIFF
--- a/documentation/api-reference.md
+++ b/documentation/api-reference.md
@@ -430,7 +430,7 @@ Each day group contains: `local_date`, `article_count`, `articles[]` (filtered t
 
 Each article in `articles[]` includes a `starred: boolean` field reflecting the authenticated user's current star state. The value is `true` when a row exists in `article_stars` for that `(user_id, article_id)` pair, `false` otherwise. This lets `/history` render the star glyph and `aria-pressed` state server-side on initial load without a separate fetch.
 
-Each article also includes `alt_source_count: number` — the count of additional sources beyond the primary that reported the same story (`COUNT(*) FROM article_sources WHERE article_id = a.id`). A value of `0` means only one source; values `> 0` drive the `+N` suffix on the DigestCard source label across all card grids (dashboard, history, starred).
+Each article also includes `alt_source_count: number` — the count of sources in `article_sources` whose `source_url` differs from `primary_source_url` (`COUNT(*) WHERE source_url != primary_source_url`). A value of `0` means no alternative sources exist; values `> 0` drive the `+N` suffix on the DigestCard source label across all card grids (dashboard, history, starred). This matches the modal filter used on the detail page, which also excludes the primary URL from the alt-source list.
 
 `?q=` and `?tags=` are page-level URL state read client-side; they are not server query params.
 

--- a/src/components/DigestCard.astro
+++ b/src/components/DigestCard.astro
@@ -470,14 +470,12 @@ const altLabel = formatAltSourceLabel(altCount);
     letter-spacing: 0.12em;
     text-transform: uppercase;
   }
-  /* "+N" suffix sits inline with the source name. Same metadata
-     treatment (small-caps, muted text) but slightly de-emphasised
-     via reduced opacity so the publisher name stays the primary
-     attribution and the count reads as a secondary annotation. */
+  /* "+N" suffix inherits the source-name typography (size, weight,
+     letter-spacing, small-caps) so the count reads as part of the same
+     metadata line; only the colour is dimmed so the publisher stays
+     the primary attribution. */
   .digest-card__alt-count {
     opacity: 0.7;
-    font-weight: 500;
-    letter-spacing: 0.08em;
   }
 
   /* Popover — always in the DOM, hidden via visibility + opacity so

--- a/src/lib/digest-today.ts
+++ b/src/lib/digest-today.ts
@@ -125,7 +125,7 @@ export async function loadTodayPayload(
            a.title, a.details_json, a.published_at, a.ingested_at,
            (SELECT json_group_array(DISTINCT at.tag)
               FROM article_tags at WHERE at.article_id = a.id) AS tags_json,
-           (SELECT COUNT(*) FROM article_sources s WHERE s.article_id = a.id) AS alt_source_count,
+           (SELECT COUNT(*) FROM article_sources s WHERE s.article_id = a.id AND s.source_url != a.primary_source_url) AS alt_source_count,
            EXISTS(SELECT 1 FROM article_stars st WHERE st.article_id = a.id AND st.user_id = ?1) AS starred,
            EXISTS(SELECT 1 FROM article_reads rd WHERE rd.article_id = a.id AND rd.user_id = ?1) AS read
       FROM articles a

--- a/src/pages/api/history.ts
+++ b/src/pages/api/history.ts
@@ -161,7 +161,7 @@ export async function GET(context: APIContext): Promise<Response> {
       `a.published_at, a.ingested_at, a.details_json, ` +
       `(SELECT json_group_array(DISTINCT at.tag) FROM article_tags at ` +
       `WHERE at.article_id = a.id) AS tags_json, ` +
-      `(SELECT COUNT(*) FROM article_sources s WHERE s.article_id = a.id) AS alt_source_count, ` +
+      `(SELECT COUNT(*) FROM article_sources s WHERE s.article_id = a.id AND s.source_url != a.primary_source_url) AS alt_source_count, ` +
       `EXISTS(SELECT 1 FROM article_stars st WHERE st.article_id = a.id AND st.user_id = ?1) AS starred ` +
       `FROM articles a ` +
       `WHERE a.ingested_at >= ?2 ` +

--- a/src/pages/api/starred.ts
+++ b/src/pages/api/starred.ts
@@ -69,7 +69,7 @@ export async function loadStarredPayload(
            a.primary_source_name, a.primary_source_url, a.published_at,
            (SELECT json_group_array(DISTINCT at.tag)
               FROM article_tags at WHERE at.article_id = a.id) AS tags_json,
-           (SELECT COUNT(*) FROM article_sources s WHERE s.article_id = a.id) AS alt_source_count,
+           (SELECT COUNT(*) FROM article_sources s WHERE s.article_id = a.id AND s.source_url != a.primary_source_url) AS alt_source_count,
            st.starred_at,
            EXISTS(SELECT 1 FROM article_reads rd WHERE rd.article_id = a.id AND rd.user_id = ?1) AS read
       FROM article_stars st


### PR DESCRIPTION
## Summary

- Card "+N" suffix counted every row in `article_sources`; the detail-page modal filters out the row whose URL matches `articles.primary_source_url`. Re-seen articles silently triggered "+1" with nothing to show in the picker.
- SQL subquery now mirrors the modal filter (`WHERE s.article_id = a.id AND s.source_url != a.primary_source_url`) in all three callers: digest-today, history API, starred API.
- "+N" suffix style now inherits the source-name typography (11px / weight 600 / 0.12em / uppercase); only opacity 0.7 is retained for the dimmed look per user feedback.

## Test plan

- [ ] CI green
- [ ] Deploy to integration, then main
- [ ] On news.graymatter.ch, articles previously showing "+1" with empty picker now either show no suffix (no real alt) or open a populated modal
- [ ] "+N" reads at the same size/weight as the publisher name, just dimmed