### PR TITLE
feat(admin): one-button pipeline + integration cron off + README

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,14 +22,14 @@ News Digest hires the LLM. It remembers so you don't. This isn't enlightenment. 
 
 - **A curated default tag set preloaded** (`#cloudflare`, `#ai-agents`, `#mcp`, `#zero-trust`, `#supply-chain-security`, `#graymatter`…). My opinions, helpfully pre-formed for you. Add a tag the registry doesn't know and it goes feed-hunting in the background — finds sources or admits it couldn't, so you're never waiting on a ghost.
 - **Composable filters on Search & History**: tag + search + date AND together, all in the URL.
-- **Two-stage dedupe** — within a chunk and across chunks. One Anthropic launch should not become six articles just because six sites found the publish button.
+- **Two-stage dedupe** — URL-canonical clustering, then semantic. Every article gets a 768-dim embedding the moment it lands; near-duplicates collapse into a single card with the alternate publishers attached as alt-sources. One Anthropic launch should not become six articles just because six sites found the publish button. Same-publisher pairs get a small cosine penalty so two genuinely different stories from the same outlet don't get glued together by house style.
 - **Summaries that earn their word count**: 150–200 words, *what happened → how it works → why you care*.
 - **Hallucinations dropped on sight**: every LLM output has to point back to a real source, or it doesn't touch the database. Ask me how I learned that.
 - **Daily digest email** (optional): when there's news, you get headlines; when there isn't, your inbox stays quiet. Once per day in your timezone, never zero-content. Push notifications were considered. Pushed back.
 - **Starred articles outlive the cron**: 14-day retention, unless you starred it. Your saved list is forever; your unread list was a lie anyway.
 - **Federated sign-in**: GitHub or Google. Wire up one, both, or neither — the app tells the truth either way. A verified email shared across providers maps to a single account, so stars, read marks, pending discoveries, and the daily digest all live in one place no matter which button you signed in with.
 - **Looks like a real product when shared**: paste the URL into iMessage, WhatsApp, Slack, LinkedIn, or Discord — you get a brand card, not a naked URL. Surprisingly hard. Don't ask.
-- **One Worker, no servers**: Cloudflare D1 + KV + Queues + Workers AI. Ships in 30 seconds. Rollback is `wrangler rollback`, which I've used more times than I'd like to admit.
+- **One Worker, no servers**: Cloudflare D1 + KV + Queues + Workers AI + Vectorize. The vector index is the new arrival — 768 dimensions of cosine-flavoured opinion about whether two articles are secretly the same article. It's been right enough times that I no longer fight it. Ships in 30 seconds. Rollback is `wrangler rollback`, which I've used more times than I'd like to admit.
 
 ## What's *not* in it
 
@@ -99,7 +99,8 @@ Custom token via [dash.cloudflare.com/profile/api-tokens](https://dash.cloudflar
 | Account | Workers KV Storage | Edit | Auto-creates the KV namespace |
 | Account | D1 | Edit | Auto-creates the D1 database and applies migrations |
 | Account | Queues | Edit | Auto-creates `scrape-coordinator`, `scrape-chunks`, and `scrape-finalize` |
-| Account | Workers AI | Read | LLM inference for summaries + source discovery |
+| Account | Workers AI | Read | LLM inference for summaries + source discovery; bge-base-en-v1.5 for article embeddings |
+| Account | Vectorize | Edit | Auto-creates the `ai-news-embeddings` index; stores + queries 768-dim cosine embeddings for semantic dedup |
 | Zone | Zone | Read | Only when binding a custom domain; discovers the zone |
 | Zone | Workers Routes | Edit | Only when binding a custom domain; attaches the hostname |
 
@@ -111,11 +112,12 @@ The Zone scopes are skipped automatically when `APP_URL` is a `*.workers.dev` UR
 <summary><strong>What the workflow does</strong></summary>
 
 1. Resolves (or creates) the D1 database, KV namespace, and queues (`scrape-coordinator`, `scrape-chunks`, `scrape-finalize`) via [`scripts/bootstrap-resources.sh`](scripts/bootstrap-resources.sh)
-2. Applies D1 migrations
-3. Pushes Worker secrets (Resend pair skipped when unset)
-4. `wrangler deploy`
-5. Binds `APP_URL` to the Worker (skipped on `*.workers.dev`)
-6. Smoke-tests `GET /` returns 200
+2. Resolves (or creates) the `ai-news-embeddings` Vectorize index (768-dim cosine)
+3. Applies D1 migrations
+4. Pushes Worker secrets (Resend pair skipped when unset)
+5. `wrangler deploy`
+6. Binds `APP_URL` to the Worker (skipped on `*.workers.dev`)
+7. Smoke-tests `GET /` returns 200
 
 </details>
 

--- a/src/pages/settings.astro
+++ b/src/pages/settings.astro
@@ -518,24 +518,32 @@ const primaryCta = isFirstRun ? 'Save and continue' : 'Save';
           </fieldset>
           {isAdmin && (
             <fieldset class="settings__section">
-              <legend class="settings__legend">Force refresh</legend>
+              <legend class="settings__legend">Run pipeline now</legend>
               <p class="settings__hint">
-                Fire the global scrape pipeline immediately instead of
-                waiting for the next 4-hour tick. Useful after a deploy
-                to verify the coordinator + chunk consumer end-to-end.
-                This endpoint is gated by Cloudflare Access — only
-                operators with an Access session can reach it.
+                Trigger the full scrape → embed → dedup pipeline
+                immediately instead of waiting for the next 4-hour
+                cron tick. Useful after a deploy to verify the change
+                end-to-end. Admin-only; gated by Cloudflare Access.
               </p>
+              <label class="settings__hint" style="display:block;margin:0.5rem 0 0.75rem">
+                <input type="checkbox" data-pipeline-wipe />
+                {' '}Wipe & re-embed all existing articles (post-deploy only — slow)
+              </label>
               <div class="settings__actions-row">
-                <form method="post" action="/api/admin/force-refresh">
-                  <button
-                    type="submit"
-                    class="settings__secondary-button"
-                  >
-                    Force refresh now
-                  </button>
-                </form>
+                <button
+                  type="button"
+                  class="settings__secondary-button"
+                  data-pipeline-run
+                >
+                  Run now
+                </button>
               </div>
+              <p
+                class="settings__status"
+                data-pipeline-status
+                aria-live="polite"
+                hidden
+              ></p>
               {/* Live progress line for any in-flight scrape run. Hidden
                   by default; the script at the bottom of this page polls
                   /api/scrape-status every 5s and fills it with a
@@ -544,64 +552,6 @@ const primaryCta = isFirstRun ? 'Save and continue' : 'Save';
               <p
                 class="settings__status"
                 data-scrape-progress
-                aria-live="polite"
-                hidden
-              ></p>
-            </fieldset>
-          )}
-          {isAdmin && (
-            <fieldset class="settings__section">
-              <legend class="settings__legend">Embed historic articles</legend>
-              <p class="settings__hint">
-                Generate Vectorize embeddings for every D1 article that
-                doesn't have one yet. Drives the full backfill in one
-                request — the server loops in batches until done, then
-                redirects back here with the outcome. If the platform
-                cuts the request before draining the backlog, click
-                again to resume. Safe to re-run; idempotent.
-              </p>
-              <div class="settings__actions-row">
-                <form method="post" action="/api/admin/embed-backfill">
-                  <button
-                    type="submit"
-                    class="settings__secondary-button"
-                  >
-                    Embed all historic articles
-                  </button>
-                </form>
-              </div>
-              <p
-                class="settings__status"
-                data-embed-status
-                aria-live="polite"
-                hidden
-              ></p>
-            </fieldset>
-          )}
-          {isAdmin && (
-            <fieldset class="settings__section">
-              <legend class="settings__legend">Dedupe historic articles</legend>
-              <p class="settings__hint">
-                Walk the embedded corpus oldest-first and merge any
-                newer near-duplicates into the older article as
-                alt-sources. Same one-request loop shape as the embed
-                button — re-clickable if the platform cuts the request.
-                Idempotent; running it again on a clean corpus merges
-                nothing.
-              </p>
-              <div class="settings__actions-row">
-                <form method="post" action="/api/admin/historical-dedup">
-                  <button
-                    type="submit"
-                    class="settings__secondary-button"
-                  >
-                    Dedupe historic articles
-                  </button>
-                </form>
-              </div>
-              <p
-                class="settings__status"
-                data-dedup-status
                 aria-live="polite"
                 hidden
               ></p>
@@ -947,6 +897,203 @@ const primaryCta = isFirstRun ? 'Save and continue' : 'Save';
     }
   }
 
+  /** Orchestrate a manual cron-equivalent pipeline run from the
+   *  Settings page. Replaces the three separate admin buttons (force
+   *  refresh, embed backfill, historical dedup) with one chained
+   *  client-side flow that consumes the existing JSON endpoints.
+   *
+   *  Phases:
+   *    0. (optional) Wipe + re-embed all articles via
+   *       POST /api/admin/embed-backfill?reembed=1, looped on
+   *       remaining > 0 in case the platform cuts the request.
+   *    1. Kick the scrape coordinator via
+   *       GET /api/admin/force-refresh (Accept: application/json).
+   *    2. Poll /api/scrape-status?run_id=… every 5s until the run
+   *       reports running:false. The existing pollScrapeProgress()
+   *       paints the live "X% — N articles ingested" line into
+   *       [data-scrape-progress] in parallel.
+   *    3. Drain any new NULL/failed embeddings via
+   *       POST /api/admin/embed-backfill (no reembed flag).
+   *    4. Run the oldest-first dedup sweep via
+   *       POST /api/admin/historical-dedup until done.
+   *
+   *  Status text streams into [data-pipeline-status] one phase at a
+   *  time; the button is disabled until the chain finishes (or
+   *  errors). All endpoints are gated by Cloudflare Access + the
+   *  three-layer admin auth helper, so an unauthenticated tab here
+   *  surfaces the auth failure as a "Failed: HTTP 401" line. */
+  async function runPipeline(wipe: boolean): Promise<void> {
+    const status = document.querySelector<HTMLElement>('[data-pipeline-status]');
+    const button = document.querySelector<HTMLButtonElement>('[data-pipeline-run]');
+    if (status === null || button === null) return;
+    const setStatus = (msg: string): void => {
+      status.hidden = false;
+      status.textContent = msg;
+    };
+    button.disabled = true;
+    try {
+      // Phase 0 — wipe + re-embed all (optional). The server marks
+      // every row 'failed' on the first request, then re-embeds in
+      // batches inside that same request until remaining=0 (or it
+      // hits the platform request-time ceiling). The while-loop
+      // resumes from where the cut left off.
+      if (wipe) {
+        setStatus('Wiping & re-embedding all articles…');
+        let total = 0;
+        let firstCall = true;
+        while (true) {
+          const url = firstCall
+            ? '/api/admin/embed-backfill?reembed=1'
+            : '/api/admin/embed-backfill';
+          const res = await fetch(url, {
+            method: 'POST',
+            credentials: 'same-origin',
+            headers: { Accept: 'application/json' },
+          });
+          if (!res.ok) throw new Error(`re-embed HTTP ${res.status}`);
+          const body = (await res.json()) as {
+            processed: number;
+            remaining: number;
+            done: boolean;
+          };
+          total += body.processed;
+          if (body.done) break;
+          // Server's forward-progress guard returns done:false +
+          // processed:0 when an entire batch failed (Workers AI or
+          // Vectorize outage). Re-clicking won't help right now —
+          // bail with a useful message instead of looping.
+          if (body.processed === 0) {
+            throw new Error(
+              `re-embed stalled at ${body.remaining} remaining (upstream outage?)`,
+            );
+          }
+          firstCall = false;
+          setStatus(`Re-embedded ${total} articles, ${body.remaining} remaining…`);
+        }
+        setStatus(`Re-embedded ${total} articles. Kicking scrape…`);
+      } else {
+        setStatus('Kicking scrape…');
+      }
+
+      // Phase 1 — force refresh. GET path supports JSON; POST always
+      // 303-redirects, which fetch can't read across origin without
+      // following the redirect into HTML. GET is idempotent enough
+      // here (the underlying coordinator dispatch is the side effect
+      // either way; admin auth still gates).
+      const frRes = await fetch('/api/admin/force-refresh', {
+        credentials: 'same-origin',
+        headers: { Accept: 'application/json' },
+      });
+      if (!frRes.ok) throw new Error(`force-refresh HTTP ${frRes.status}`);
+      const frBody = (await frRes.json()) as {
+        scrape_run_id: string;
+        reused: boolean;
+      };
+      pinnedRunId = frBody.scrape_run_id;
+      setStatus(
+        frBody.reused
+          ? 'Scrape already running; waiting for it to finish…'
+          : 'Scrape kicked; waiting for it to finish…',
+      );
+
+      // Phase 2 — wait for the scrape run to complete. The existing
+      // pollScrapeProgress() already polls every 5s and paints the
+      // live progress into [data-scrape-progress]; here we just
+      // sample running state with the same cadence and exit when it
+      // flips false.
+      while (true) {
+        await new Promise((r) => setTimeout(r, 5_000));
+        const sRes = await fetch(
+          `/api/scrape-status?run_id=${encodeURIComponent(frBody.scrape_run_id)}`,
+          { credentials: 'same-origin', headers: { Accept: 'application/json' } },
+        );
+        if (!sRes.ok) break;
+        const sBody = (await sRes.json()) as { running: boolean };
+        if (!sBody.running) break;
+      }
+      setStatus('Scrape finished. Embedding new articles…');
+
+      // Phase 3 — drain any embeddings the chunk-consumer didn't
+      // land (rare; only if the embed call inside the consumer threw
+      // and left rows at 'failed'). Loop on remaining for the same
+      // platform-cut reason as Phase 0.
+      let embedTotal = 0;
+      while (true) {
+        const eRes = await fetch('/api/admin/embed-backfill', {
+          method: 'POST',
+          credentials: 'same-origin',
+          headers: { Accept: 'application/json' },
+        });
+        if (!eRes.ok) throw new Error(`embed HTTP ${eRes.status}`);
+        const eBody = (await eRes.json()) as {
+          processed: number;
+          remaining: number;
+          done: boolean;
+        };
+        embedTotal += eBody.processed;
+        if (eBody.done) break;
+        if (eBody.processed === 0) {
+          throw new Error(
+            `embed stalled at ${eBody.remaining} remaining (upstream outage?)`,
+          );
+        }
+        setStatus(`Embedded ${embedTotal}, ${eBody.remaining} remaining…`);
+      }
+      setStatus(`Embedded ${embedTotal} new articles. Running dedup…`);
+
+      // Phase 4 — historical dedup, oldest-first. Same loop shape.
+      let scanned = 0;
+      let merged = 0;
+      while (true) {
+        const dRes = await fetch('/api/admin/historical-dedup', {
+          method: 'POST',
+          credentials: 'same-origin',
+          headers: { Accept: 'application/json' },
+        });
+        if (!dRes.ok) throw new Error(`dedup HTTP ${dRes.status}`);
+        const dBody = (await dRes.json()) as {
+          scanned: number;
+          merged: number;
+          remaining: number;
+          done: boolean;
+        };
+        scanned += dBody.scanned;
+        merged += dBody.merged;
+        if (dBody.done) break;
+        if (dBody.scanned === 0) {
+          throw new Error(
+            `dedup stalled at ${dBody.remaining} remaining (upstream outage?)`,
+          );
+        }
+        setStatus(
+          `Dedup: scanned ${scanned}, merged ${merged}, ${dBody.remaining} remaining…`,
+        );
+      }
+      setStatus(
+        `Done — embedded ${embedTotal} new, scanned ${scanned}, merged ${merged} duplicates.`,
+      );
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      setStatus(`Failed: ${msg}`);
+    } finally {
+      button.disabled = false;
+    }
+  }
+
+  /** Wire the [data-pipeline-run] button to runPipeline(). Idempotent —
+   *  the data-bound guard prevents double-binding on Astro SPA
+   *  navigation back to /settings. */
+  function wirePipelineButton(): void {
+    const button = document.querySelector<HTMLButtonElement>('[data-pipeline-run]');
+    if (button === null) return;
+    if (button.dataset['bound'] === '1') return;
+    button.dataset['bound'] = '1';
+    button.addEventListener('click', () => {
+      const wipe = document.querySelector<HTMLInputElement>('[data-pipeline-wipe]');
+      void runPipeline(wipe?.checked === true);
+    });
+  }
+
   function init(): void {
     // Restore + delete forms live OUTSIDE the main settings form (they
     // were hoisted to fix a nested-<form> bug). Wire them first so they
@@ -954,6 +1101,7 @@ const primaryCta = isFirstRun ? 'Save and continue' : 'Save';
     wireRestoreForm();
     wireDeleteForm();
     wireScrapeProgress();
+    wirePipelineButton();
     relabelHoursIfTwelveHourLocale();
 
     const form = document.querySelector<HTMLFormElement>('[data-settings-form]');

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -197,8 +197,14 @@ binding = "AI"
 binding = "VECTORIZE"
 index_name = "ai-news-embeddings-integration"
 
-# No [env.integration.triggers] block — crons are intentionally disabled
-# on integration. Trigger scrape runs manually via /api/admin/force-refresh.
+# Crons are intentionally disabled on integration. Trigger scrape runs
+# manually via /api/admin/force-refresh (or the consolidated "Run
+# pipeline now" button on /settings). Note: omitting this section
+# would NOT disable crons — wrangler inherits the top-level
+# `crons = [...]` array into every env that doesn't override it.
+# The empty array below is the actual override.
+[env.integration.triggers]
+crons = []
 
 # APP_URL for integration is NOT hardcoded here. The deploy workflow
 # reads `vars.APP_URL` from the GitHub Environment named "integration"


### PR DESCRIPTION
## Summary

Replaces three admin fieldsets on \`/settings\` (Force refresh, Embed historic, Dedupe historic) with one "Run pipeline now" button that chains the existing JSON endpoints client-side. Optional checkbox for "Wipe & re-embed all" handles the post-deploy bulldozer case.

Also fixes integration cron leak (wrangler env inheritance silently kept the 4-hourly tick alive on integration despite the comment claiming otherwise) and updates the README for the embedding/Vectorize stack.

## What changed

- **\`src/pages/settings.astro\`** — three fieldsets → one. Client-side orchestrator chains \`POST /api/admin/embed-backfill?reembed=1\` (when checked) → \`GET /api/admin/force-refresh\` → poll \`/api/scrape-status\` → \`POST /api/admin/embed-backfill\` (drain) → \`POST /api/admin/historical-dedup\`. Status line streams phase progress; the existing 5s scrape-status poll continues to paint live "X% — N articles ingested" alongside.
- **\`wrangler.toml\`** — explicit \`[env.integration.triggers] crons = []\` override. Wrangler env inheritance was silently keeping the top-level cron firing on integration; the comment claimed crons were off but the deploy log + D1 ingest timestamps showed otherwise.
- **\`README.md\`** — Vectorize added to the API token scopes table (Account / Vectorize / Edit). Two-stage dedupe bullet rewritten to explain the URL-canonical + semantic embedding flow and the same-publisher penalty. Stack-summary line and workflow-steps list updated.

## No server changes

All three /api/admin endpoints already supported \`Accept: application/json\`. The orchestrator just consumes those paths directly. Existing redirect-based form-POST handlers stay reachable from curl/scripts.

## Test plan

- [ ] CI green
- [ ] Click "Run now" on integration unchecked — status line shows scrape kicked → embedded N → dedup done
- [ ] Click "Run now" with "Wipe & re-embed all" checked — status line shows wipe+re-embed first, then the rest
- [ ] Verify integration cron doesn't fire (no D1 ingests at the next cron-aligned tick)