### PR TITLE
review: cycle-1 bundle (27 fixes, WIP)

### DIFF
--- a/.github/workflows/deploy-integration.yml
+++ b/.github/workflows/deploy-integration.yml
@@ -142,6 +142,13 @@ jobs:
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
         run: npx --yes wrangler queues info pipeline-jobs-integration >/dev/null 2>&1 || npx --yes wrangler queues create pipeline-jobs-integration
 
+      # CF-001 — DLQ for finalize + pipeline jobs (integration scope).
+      - name: Provision queue - ai-news-dlq-integration
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: npx --yes wrangler queues info ai-news-dlq-integration >/dev/null 2>&1 || npx --yes wrangler queues create ai-news-dlq-integration
+
       # REQ-PIPE-003 — integration uses its own Vectorize index so an
       # integration retention sweep can never delete production vectors.
       - name: Provision Vectorize index (integration)

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -146,6 +146,14 @@ jobs:
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
         run: npx --yes wrangler queues info pipeline-jobs >/dev/null 2>&1 || npx --yes wrangler queues create pipeline-jobs
 
+      # CF-001 — DLQ for finalize + pipeline jobs so terminal queue
+      # retry exhaustion produces a durable artifact rather than vanishing.
+      - name: Provision queue - ai-news-dlq
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: npx --yes wrangler queues info ai-news-dlq >/dev/null 2>&1 || npx --yes wrangler queues create ai-news-dlq
+
       # REQ-PIPE-003 — Vectorize index for semantic same-story dedup.
       # 768-dim cosine matches the @cf/baai/bge-base-en-v1.5 embedding
       # model. Forks that swap the model must update both this step

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -63,6 +63,12 @@ jobs:
       - name: REQ backlink coverage
         run: node scripts/check-req-backlinks.mjs
 
+      # CF-016 — wrangler.toml [vars] and [env.integration.vars] must
+      # share the same key set so a missing variable can't silently
+      # change behavior on one env but not the other.
+      - name: Wrangler vars parity (prod vs integration)
+        run: node scripts/check-wrangler-vars-parity.mjs
+
       # AD20 — fail the build if any src/pages/** or src/components/**
       # statically imports a top-level src/scripts/*.ts file. That
       # double-bundles the script (standalone IIFE + page chunk),

--- a/documentation/decisions/README.md
+++ b/documentation/decisions/README.md
@@ -56,6 +56,8 @@ Each ADR documents a non-obvious design choice and the trade-offs considered. De
 | AD40 | Add equal-time ULID tie-break, high-confidence cosine band, topK bump, and per-article diagnostic logs to dedup | Architecture | 2026-05-09 |
 | AD41 | Bidirectional finalize merge + automatic post-tick dedup sweep | Architecture | 2026-05-09 |
 | AD42 | Bidirectional historical-dedup + sweep cursor aligned with time window + multi-rerank | Architecture | 2026-05-10 |
+| AD43 | Shared per-match dedup classifier; outer control flow stays per-consumer | Architecture | 2026-05-12 |
+| AD44 | Cloudflare Access JWT `exp` validation; signature still trusted from the perimeter | Security | 2026-05-12 |
 
 ---
 
@@ -1195,6 +1197,56 @@ Three reasons the AD41 fix did not collapse this cluster:
 - This fix is forward-only. The 2026-05-10 fragmented Cloudflare-layoffs cluster is collapsed by the operator-triggered full-corpus historical-dedup sweep that runs alongside this commit; future clusters of similar shape collapse on first finalize tick after the latest sibling lands.
 
 **Related requirements:** [REQ-PIPE-003](../../sdd/generation.md#req-pipe-003-same-story-dedupe-across-the-entire-article-history) (AC 15 reworded; AC 17 added), [REQ-PIPE-009](../../sdd/generation.md#req-pipe-009-llm-rerank-for-borderline-cosine-pairs) (AC 5 reworded for multi-rerank cap)
+
+---
+
+### AD43: Shared per-match dedup classifier; outer control flow stays per-consumer
+
+**Status:** Accepted (2026-05-12)
+
+**Decision:** Both the per-tick finalize consumer and the historical sweep delegate per-match scoring to one classifier (`classifyMatchPair` in `src/lib/bidirectional-dedup.ts`) while keeping their own outer control flow.
+
+**Context:** Pre-AD43 each consumer reimplemented the same per-match logic — time-window gate, high-confidence band, same-vendor penalty, threshold gate, rerank floor, equal-time ULID tie-break, direction flag. Cycle-1 review flagged the drift as CF-002: the two implementations subtly disagreed on what counted as a borderline pair (the historical sweep had no rerank cap; finalize capped at 5), and any future tuning had to be applied in two places under the constant risk of partial application.
+
+**Alternatives considered:**
+- A fully unified `pickMergeDecision(env, self, matches, options)` that owned both per-match scoring AND winner selection AND rerank dispatch. Rejected: the two consumers have fundamentally different intents (finalize picks one chosen pair per article; the historical sweep runs PASS 1 looking for the oldest anchor + PASS 2 absorbing newer matches sequentially). A unified decision function would have re-encoded the per-consumer divergence as a parameter matrix instead of removing it.
+- Leave the two implementations as-is and rely on review discipline to keep them in sync. Rejected: the drift CF-002 surfaced is the empirical evidence that this doesn't hold.
+
+**Rationale:** The classifier captures the part of the logic that is genuinely shared (per-pair scoring rules and band classification). The outer control flow — single-pass winner selection in finalize vs PASS 1/PASS 2 anchor-and-absorb in the historical sweep — is genuinely different intent and belongs at the call site. The split makes the boundary explicit instead of letting it drift.
+
+**Consequences:**
+
+- Both consumers now produce identical band classifications for the same (self, match, params) tuple, eliminating CF-002's drift class.
+- Outer control flow is preserved verbatim. Finalize keeps RERANK_CANDIDATE_CAP=5; the historical sweep keeps its no-cap pattern (the queue consumer has a 15-min budget per message). The per-consumer caps are explicit and visible at each call site.
+- Future tuning of the scoring rules (e.g., adding a tertiary penalty) happens in one place.
+- CF-029 (cache the comparator secondary key) is satisfied naturally — each match is classified exactly once and reuses the result.
+
+**Related requirements:** [REQ-PIPE-003](../../sdd/generation.md#req-pipe-003-same-story-dedupe-across-the-entire-article-history), [REQ-PIPE-009](../../sdd/generation.md#req-pipe-009-llm-rerank-for-borderline-cosine-pairs)
+
+---
+
+### AD44: Cloudflare Access JWT `exp` validation; signature still trusted from the perimeter
+
+**Status:** Accepted (2026-05-12)
+
+**Decision:** `decodeAccessJwt` in `src/middleware/admin-auth.ts` now validates the `exp` claim is present and in the future. JWT signature continues to be unverified server-side (AD25 → AD29).
+
+**Context:** Cycle-1 review flagged CF-007: the access-token decoder accepted any well-formed JSON payload, including one with no `exp` claim or an `exp` in the past. Cloudflare Access stamps `exp` on every legitimate token, and the perimeter rejects expired tokens before they reach the worker. But defence-in-depth requires the worker to also reject expired tokens — a stolen long-lived token from before a rotation window, or a synthetic non-Access token that somehow reached the worker, would otherwise pass admin auth despite being unusable upstream.
+
+**Alternatives considered:**
+- Verify the JWT signature server-side. Rejected per AD29: requires fetching the JWKS, caching it in KV with rotation, and the perimeter already does this. The signature trust boundary stays at Access.
+- Validate every JWT claim Cloudflare Access emits (`iat`, `iss`, `nbf`). Rejected: not all claims are stable across Access versions, and the security delta over `exp` alone is negligible since the perimeter already enforces them.
+
+**Rationale:** `exp` is the one claim with concrete defence-in-depth value: it catches the long-lived-stolen-token replay class without re-litigating the signature-trust boundary AD29 established. The check is a single comparison against `Date.now()`, no external dependencies.
+
+**Consequences:**
+
+- A long-lived stolen Access JWT from before the perimeter rotated keys is now rejected even if it somehow reaches the worker.
+- A synthetic non-Access JWT missing `exp` is rejected with the same null path as malformed payloads.
+- Test fixtures that minted Access JWTs without `exp` need to add one (single fixture function change).
+- Signature trust still terminates at the Access perimeter. Worker code does not verify the RS256 signature, and AD29 + AD30 remain the governing decisions for the perimeter contract.
+
+**Related requirements:** [REQ-AUTH-001](../../sdd/authentication.md#req-auth-001-sign-in-with-a-federated-identity-provider)
 
 ---
 

--- a/migrations/0015_scrape_runs_wait_iterations.sql
+++ b/migrations/0015_scrape_runs_wait_iterations.sql
@@ -1,0 +1,6 @@
+-- 0015_scrape_runs_wait_iterations.sql
+-- CF-001: track how many times the pipeline scrape_wait phase has
+-- re-enqueued itself for a given scrape_run, so the pipeline can fail
+-- out of an unbounded wait loop instead of looping forever.
+
+ALTER TABLE scrape_runs ADD COLUMN wait_iterations INTEGER NOT NULL DEFAULT 0;

--- a/scripts/check-wrangler-vars-parity.mjs
+++ b/scripts/check-wrangler-vars-parity.mjs
@@ -1,0 +1,65 @@
+// CF-016: fail CI when wrangler.toml's top-level [vars] block and
+// [env.integration.vars] block drift apart in KEY set. Production and
+// integration must expose the same env-var names so a missing key
+// can't silently change behavior on one but not the other. Values
+// are allowed to differ (and often do — e.g., feature flags).
+
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const tomlPath = resolve(here, '..', 'wrangler.toml');
+const text = readFileSync(tomlPath, 'utf-8');
+
+function parseSection(name) {
+  // Match a section header on its own line, then read until the next
+  // section header or EOF. Strip comments and blank lines.
+  const re = new RegExp(`^\\[${name.replace(/\./g, '\\.')}\\]\\s*$`, 'm');
+  const m = re.exec(text);
+  if (m === null) return null;
+  const start = m.index + m[0].length;
+  const nextHeader = /^\[/m.exec(text.slice(start));
+  const body =
+    nextHeader === null ? text.slice(start) : text.slice(start, start + nextHeader.index);
+  const keys = new Set();
+  for (const line of body.split('\n')) {
+    const trimmed = line.replace(/^\s+/, '');
+    if (trimmed === '' || trimmed.startsWith('#')) continue;
+    const eq = trimmed.indexOf('=');
+    if (eq === -1) continue;
+    const key = trimmed.slice(0, eq).trim();
+    if (key === '') continue;
+    keys.add(key);
+  }
+  return keys;
+}
+
+const prod = parseSection('vars');
+const integ = parseSection('env.integration.vars');
+
+if (prod === null) {
+  console.error('FAIL: wrangler.toml missing [vars] section');
+  process.exit(1);
+}
+if (integ === null) {
+  console.error('FAIL: wrangler.toml missing [env.integration.vars] section');
+  process.exit(1);
+}
+
+const onlyInProd = [...prod].filter((k) => !integ.has(k));
+const onlyInInteg = [...integ].filter((k) => !prod.has(k));
+
+if (onlyInProd.length === 0 && onlyInInteg.length === 0) {
+  console.log(`OK: wrangler.toml [vars] and [env.integration.vars] keys match (${prod.size} keys)`);
+  process.exit(0);
+}
+
+console.error('FAIL: wrangler.toml [vars] and [env.integration.vars] keys diverge.');
+if (onlyInProd.length > 0) {
+  console.error('  Only in [vars]:                 ' + onlyInProd.sort().join(', '));
+}
+if (onlyInInteg.length > 0) {
+  console.error('  Only in [env.integration.vars]: ' + onlyInInteg.sort().join(', '));
+}
+process.exit(1);

--- a/sdd/changes.md
+++ b/sdd/changes.md
@@ -6,6 +6,14 @@ Each entry is dated, ≤2 sentences, user-facing only. No commit SHAs. No "verif
 
 Entries from 2026-04-22 through 2026-04-26 (the global-feed rework window) are archived in [`changes-archive-2026-04.md`](changes-archive-2026-04.md).
 
+## 2026-05-12
+
+- REQ-PIPE-003 AC reworded: a corpus-wide same-story search during a Vectorize outage no longer silently advances past the affected articles. The sweep now pauses and resumes once the index is reachable, so cross-tick duplicates that landed during the outage still collapse on the next attempt instead of staying split forever.
+- REQ-PIPE-001 AC reworded: a stuck pipeline run that has been waiting on its scrape phase for longer than the configured budget now exits with a failed status visible in the dashboard, instead of looping silently until queue retries exhaust. Operators see the stall promptly and can re-kick the pipeline.
+- REQ-AUTH-001 AC reworded: admin-only actions (force-refresh, full pipeline run) now also reject after too many attempts in a short window, regardless of authentication. The previous behaviour bounded only unauthenticated traffic; the new bound prevents a compromised or accidentally-looping admin session from driving runaway pipeline kicks.
+- REQ-AUTH-001 AC reworded: the destructive wipe-and-re-embed pipeline mode now requires an explicit POST. Visiting the URL via GET returns a method-not-allowed response, so cross-origin GET vectors (image tags, bookmarks, link previews) can no longer trigger a full corpus re-embed.
+- REQ-AUTH-001 AC extended: an access token forwarded by the perimeter is now rejected when its expiry claim is in the past or missing, in addition to the existing audience check.
+
 ## 2026-05-10
 
 - REQ-PIPE-003 AC 17 added and AC 15 reworded: same-story clusters that span more than two days now collapse without operator intervention. Until now a duplicate that landed three days after its first sibling stayed visibly separate (the post-tick auto-sweep only reached 48 hours back while the same-event window already covered 72 hours), so a press-release reverberating across publishers over a long weekend produced multiple cards instead of one. The auto-sweep now reaches the full 72-hour window and treats either article in the pair as a possible cluster anchor, so newer arrivals fold into older ones and vice versa.

--- a/src/lib/bidirectional-dedup.ts
+++ b/src/lib/bidirectional-dedup.ts
@@ -38,7 +38,8 @@ export interface SelfArticle {
 export interface MatchInput {
   id: string;
   score: number;
-  metadata: unknown;
+  /** Matches `VectorizeMatch.metadata` shape — optional record. */
+  metadata?: Record<string, unknown> | undefined;
 }
 
 export type ClassifyOutcome =
@@ -71,11 +72,11 @@ export function classifyMatchPair(
   match: MatchInput,
   params: ClassifierParams,
 ): ClassifyOutcome {
-  const meta = match.metadata as
-    | { published_at?: unknown; primary_source_url?: unknown }
-    | undefined;
+  const meta = match.metadata;
   const matchPublishedAt =
-    typeof meta?.published_at === 'number' ? meta.published_at : null;
+    typeof meta?.['published_at'] === 'number'
+      ? (meta['published_at'] as number)
+      : null;
   if (matchPublishedAt === null) return { kind: 'no_metadata' };
 
   const deltaSeconds = Math.abs(self.published_at - matchPublishedAt);
@@ -85,7 +86,9 @@ export function classifyMatchPair(
 
   const isHighConfidence = match.score >= params.highConfidenceCosine;
   const matchUrl =
-    typeof meta?.primary_source_url === 'string' ? meta.primary_source_url : '';
+    typeof meta?.['primary_source_url'] === 'string'
+      ? (meta['primary_source_url'] as string)
+      : '';
   const sameEtld1 =
     matchUrl !== '' && sameVendor(self.primary_source_url, matchUrl);
   const adjustedScore =

--- a/src/lib/bidirectional-dedup.ts
+++ b/src/lib/bidirectional-dedup.ts
@@ -1,0 +1,117 @@
+// Implements REQ-PIPE-003
+// Implements REQ-PIPE-009
+//
+// Shared per-match classifier used by both the per-tick finalize
+// consumer (`src/queue/scrape-finalize-consumer.ts`) and the
+// historical sweep (`src/lib/historical-dedup.ts`). Pre-extraction,
+// each call site reimplemented the same scoring/banding logic with
+// drift between them (CF-002): same-vendor penalty, high-confidence
+// band, time-window gate, equal-time tie-break, direction flag —
+// all encoded twice with subtle wording differences. The shared
+// classifier resolves the drift by routing both call sites through
+// one expression.
+//
+// The classifier is per-match only. It does NOT pick a winner —
+// each call site has its own outer control flow (finalize picks one
+// chosen pair per article + reranks borderline candidates capped at
+// RERANK_CANDIDATE_CAP; historical-dedup runs PASS 1 + PASS 2 with
+// no rerank cap because the queue consumer has a 15-min budget per
+// message). The decision shape (best-auto, borderline candidate
+// list, decision label) stays at the call site.
+
+import { sameVendor } from '~/lib/etld';
+
+export interface ClassifierParams {
+  threshold: number;
+  sameVendorPenalty: number;
+  rerankFloor: number;
+  timeWindowSeconds: number;
+  highConfidenceCosine: number;
+}
+
+export interface SelfArticle {
+  id: string;
+  published_at: number;
+  primary_source_url: string;
+}
+
+export interface MatchInput {
+  id: string;
+  score: number;
+  metadata: unknown;
+}
+
+export type ClassifyOutcome =
+  /** Match published_at missing — Vectorize metadata corrupt or pre-AD40 vector. */
+  | { kind: 'no_metadata' }
+  /** Pair separated by more than the configured time window — skipped regardless of cosine. */
+  | { kind: 'out_of_window'; matchPublishedAt: number; deltaSeconds: number }
+  /** Eligible candidate with full scoring derived. The call site decides what to do with it. */
+  | {
+      kind: 'eligible';
+      matchPublishedAt: number;
+      deltaSeconds: number;
+      adjustedScore: number;
+      isHighConfidence: boolean;
+      /** True iff `(highConfidence) || (adjustedScore >= threshold)` — clears the auto-merge gate. */
+      isAutoMerge: boolean;
+      /** True iff `!isAutoMerge && adjustedScore >= rerankFloor` — needs the LLM rerank to decide. */
+      isBorderline: boolean;
+      /** Direction flag. true ⇒ self is older (equal-time tie-broken by lower ULID). */
+      selfIsOlder: boolean;
+      /** Same registrable domain (`eTLD+1`) — true when both URLs share a vendor. */
+      sameEtld1: boolean;
+    };
+
+/** Classify one (self, match) pair under the supplied dedup params.
+ *  Both finalize and historical sweep call this for every candidate
+ *  returned by Vectorize.queryById. */
+export function classifyMatchPair(
+  self: SelfArticle,
+  match: MatchInput,
+  params: ClassifierParams,
+): ClassifyOutcome {
+  const meta = match.metadata as
+    | { published_at?: unknown; primary_source_url?: unknown }
+    | undefined;
+  const matchPublishedAt =
+    typeof meta?.published_at === 'number' ? meta.published_at : null;
+  if (matchPublishedAt === null) return { kind: 'no_metadata' };
+
+  const deltaSeconds = Math.abs(self.published_at - matchPublishedAt);
+  if (deltaSeconds > params.timeWindowSeconds) {
+    return { kind: 'out_of_window', matchPublishedAt, deltaSeconds };
+  }
+
+  const isHighConfidence = match.score >= params.highConfidenceCosine;
+  const matchUrl =
+    typeof meta?.primary_source_url === 'string' ? meta.primary_source_url : '';
+  const sameEtld1 =
+    matchUrl !== '' && sameVendor(self.primary_source_url, matchUrl);
+  const adjustedScore =
+    sameEtld1 && !isHighConfidence
+      ? match.score - params.sameVendorPenalty
+      : match.score;
+
+  const isAutoMerge = isHighConfidence || adjustedScore >= params.threshold;
+  const isBorderline = !isAutoMerge && adjustedScore >= params.rerankFloor;
+
+  // Equal-time tie-break: lower ULID = older (deterministic across
+  // both consumers so the chosen winner is consistent regardless of
+  // which path observed the pair first).
+  const selfIsOlder =
+    self.published_at < matchPublishedAt ||
+    (self.published_at === matchPublishedAt && self.id < match.id);
+
+  return {
+    kind: 'eligible',
+    matchPublishedAt,
+    deltaSeconds,
+    adjustedScore,
+    isHighConfidence,
+    isAutoMerge,
+    isBorderline,
+    selfIsOlder,
+    sameEtld1,
+  };
+}

--- a/src/lib/crypto.ts
+++ b/src/lib/crypto.ts
@@ -115,7 +115,9 @@ export async function verifyHmacSignature(
 export function hexEncode(bytes: Uint8Array): string {
   let out = '';
   for (let i = 0; i < bytes.length; i++) {
-    out += bytes[i]!.toString(16).padStart(2, '0');
+    const b = bytes[i];
+    if (b === undefined) continue; // unreachable: i < bytes.length
+    out += b.toString(16).padStart(2, '0');
   }
   return out;
 }

--- a/src/lib/discovery.ts
+++ b/src/lib/discovery.ts
@@ -269,6 +269,8 @@ function hasXmlItem(body: string, kind: 'rss' | 'atom'): boolean {
       ignoreAttributes: false,
       attributeNamePrefix: '@_',
       trimValues: true,
+      // CF-010: disable entity expansion (same rationale as sources.ts).
+      processEntities: false,
     });
     doc = parser.parse(body);
   } catch {

--- a/src/lib/error-sanitize.ts
+++ b/src/lib/error-sanitize.ts
@@ -1,0 +1,45 @@
+// CF-028: shared helper for stamping error details into structured
+// logs / DB columns. Strips stack frames, file path prefixes, and
+// token-shaped substrings (`Bearer ...`, anything that resembles a
+// URL with credentials, hex blobs ≥40 chars). The output is suitable
+// for surfacing to operators via wrangler tail or admin dashboards
+// without leaking the worker's filesystem layout or any secret
+// material that an exception accidentally captured.
+//
+// Length-bounded so the caller doesn't need to slice again — D1's
+// TEXT columns have no hard cap but `wrangler tail` truncates long
+// lines, and downstream parsers like the settings dashboard render
+// errors inline.
+
+/** Maximum characters returned by sanitizeErrorDetail. Matches the
+ *  per-line log payload budget used elsewhere in the codebase. */
+const MAX_CHARS = 500;
+
+/** Stack-frame line: `    at ...` (Node) or `... at file:///...` (V8). */
+const STACK_FRAME_RE = /^\s*at\s.+$/gm;
+
+/** `Bearer <token>` (case-insensitive). */
+const BEARER_TOKEN_RE = /\bBearer\s+[A-Za-z0-9._~+/=-]+/gi;
+
+/** Hex blobs of ≥40 chars (covers SHA-1+ digests and token prefixes). */
+const HEX_BLOB_RE = /\b[0-9a-fA-F]{40,}\b/g;
+
+/** `proto://user:pass@host` URL credentials. */
+const URL_CREDS_RE = /\b([a-z][a-z0-9+.-]*:\/\/)[^\s/@]+@/gi;
+
+/** Absolute filesystem paths (Unix + Windows). */
+const FS_PATH_RE = /(?:^|\s)((?:\/[^\s/:]+){2,}|[A-Za-z]:\\[^\s]+)/g;
+
+export function sanitizeErrorDetail(err: unknown): string {
+  let detail = err instanceof Error ? `${err.name}: ${err.message}` : String(err);
+  detail = detail
+    .replace(STACK_FRAME_RE, '')
+    .replace(BEARER_TOKEN_RE, 'Bearer <redacted>')
+    .replace(HEX_BLOB_RE, '<redacted-hex>')
+    .replace(URL_CREDS_RE, '$1<redacted>@')
+    .replace(FS_PATH_RE, ' <path>')
+    .replace(/\s+/g, ' ')
+    .trim();
+  if (detail.length > MAX_CHARS) detail = detail.slice(0, MAX_CHARS);
+  return detail;
+}

--- a/src/lib/historical-dedup.ts
+++ b/src/lib/historical-dedup.ts
@@ -135,17 +135,30 @@ export async function runHistoricalDedupBatch(
   let merged = 0;
   let rerankCallsThisBatch = 0;
   let rerankAccepts = 0;
+  // CF-004: align with scrape-finalize-consumer total-outage behavior.
+  // finalize throws when `queriesFailed === queriesAttempted > 0` so the
+  // gate stays un-flipped and queue retries cover Vectorize recovery.
+  // historical-dedup previously logged + `continue`d, letting the cursor
+  // advance past failed selves and silently leaving cross-tick duplicates
+  // unmerged during a corpus-wide outage. We now track attempts/failures
+  // and short-circuit the batch on total outage, returning `done: false`
+  // with the INPUT cursor unchanged so the queue-driven sweep re-attempts
+  // the same range on the next message instead of skipping it.
+  let queriesAttempted = 0;
+  let queriesFailed = 0;
 
   for (const self of rows) {
     if (removedIds.has(self.id)) continue;
 
     let queryResult: VectorizeMatches;
+    queriesAttempted += 1;
     try {
       queryResult = await env.VECTORIZE.queryById(self.id, {
         topK: VECTORIZE_TOPK,
         returnMetadata: 'all',
       });
     } catch (err) {
+      queriesFailed += 1;
       log('warn', 'digest.generation', {
         status: 'historical_dedup_query_failed',
         article_id: self.id,
@@ -366,6 +379,35 @@ export async function runHistoricalDedupBatch(
       removedIds.add(match.id);
       merged += 1;
     }
+  }
+
+  // CF-004 total-outage gate. If every Vectorize query in this batch
+  // failed, the dedup decision for every row is "unknown" — advancing
+  // the cursor would silently strand same-event cross-tick pairs once
+  // Vectorize recovers, mirroring the production failure mode the
+  // scrape-finalize-consumer already guards against by throwing.
+  // Short-circuit with the INPUT cursor preserved so the queue-driven
+  // self-chain re-attempts the same range on the next consumer message
+  // (queue back-pressure provides the retry delay). The admin endpoint
+  // surface this as `done: false` with the same cursor — operators can
+  // re-poll once Vectorize is healthy.
+  if (queriesAttempted > 0 && queriesFailed === queriesAttempted) {
+    log('error', 'digest.generation', {
+      status: 'historical_dedup_vectorize_total_outage',
+      scanned: rows.length,
+      queries_attempted: queriesAttempted,
+      queries_failed: queriesFailed,
+      cursor_pa: cursor?.pa ?? null,
+      cursor_id: cursor?.id ?? null,
+    });
+    return {
+      ok: true,
+      scanned: rows.length,
+      merged: 0,
+      next_cursor: cursor,
+      remaining: rows.length,
+      done: false,
+    };
   }
 
   // Page deletes at 100 ids per call to stay under the platform delete-

--- a/src/lib/historical-dedup.ts
+++ b/src/lib/historical-dedup.ts
@@ -29,7 +29,7 @@ import {
   deleteVectorsBatched,
 } from '~/lib/embeddings';
 import { readRerankFloor, rerankBorderlinePair } from '~/lib/dedup-rerank';
-import { sameVendor } from '~/lib/etld';
+import { classifyMatchPair } from '~/lib/bidirectional-dedup';
 
 /** Default articles scanned per call when the caller omits `batch`.
  *  Sized so a single batch's worst-case (25 × Vectorize.queryById +
@@ -186,40 +186,28 @@ export async function runHistoricalDedupBatch(
     // auto-merge candidate STRICTLY OLDER than self. If found, self
     // folds into that anchor and we move to the next outer row — self
     // is now a loser, no further matches matter.
+    const classifierParams = {
+      threshold,
+      sameVendorPenalty,
+      rerankFloor,
+      timeWindowSeconds,
+      highConfidenceCosine,
+    };
     let foldIntoOlder: { id: string; pa: number } | null = null;
     for (const match of matches) {
       if (match.id === self.id) continue;
       if (removedIds.has(match.id)) continue;
-      const meta = match.metadata as
-        | { published_at?: unknown; primary_source_url?: unknown }
-        | undefined;
-      const matchPublishedAt =
-        typeof meta?.published_at === 'number' ? meta.published_at : null;
-      if (matchPublishedAt === null) continue;
-      const deltaSeconds = Math.abs(self.published_at - matchPublishedAt);
-      if (deltaSeconds > timeWindowSeconds) continue;
-      // Only the strict-older direction. Equal-time + lower ULID also
-      // counts as "older" — same tie-break as AD39's equal-time path.
-      const matchIsOlder =
-        matchPublishedAt < self.published_at ||
-        (matchPublishedAt === self.published_at && match.id < self.id);
-      if (!matchIsOlder) continue;
-      const isHighConfidence = match.score >= highConfidenceCosine;
-      const matchUrl =
-        typeof meta?.primary_source_url === 'string'
-          ? meta.primary_source_url
-          : '';
-      const sameEtld1 =
-        matchUrl !== '' && sameVendor(self.primary_source_url, matchUrl);
-      const adjustedScore = sameEtld1 && !isHighConfidence
-        ? match.score - sameVendorPenalty
-        : match.score;
-      const isAutoMerge = isHighConfidence || adjustedScore >= threshold;
-      if (!isAutoMerge) continue;
+      const c = classifyMatchPair(self, match, classifierParams);
+      if (c.kind !== 'eligible') continue;
+      // PASS 1 — only strict-older direction (selfIsOlder=false ⇒
+      // match is older). Auto-merge band only; borderline candidates
+      // are handled by PASS 2's rerank path.
+      if (c.selfIsOlder) continue;
+      if (!c.isAutoMerge) continue;
       // Prefer the OLDEST auto-merge match — the deepest-rooted anchor
       // for the cluster.
-      if (foldIntoOlder === null || matchPublishedAt < foldIntoOlder.pa) {
-        foldIntoOlder = { id: match.id, pa: matchPublishedAt };
+      if (foldIntoOlder === null || c.matchPublishedAt < foldIntoOlder.pa) {
+        foldIntoOlder = { id: match.id, pa: c.matchPublishedAt };
       }
     }
 
@@ -269,57 +257,27 @@ export async function runHistoricalDedupBatch(
     for (const match of matches) {
       if (match.id === self.id) continue;
       if (removedIds.has(match.id)) continue;
-      const meta = match.metadata as
-        | { published_at?: unknown; primary_source_url?: unknown }
-        | undefined;
-      const matchPublishedAt =
-        typeof meta?.published_at === 'number' ? meta.published_at : null;
-      if (matchPublishedAt === null) continue;
-      // Hard time-window gate — pairs published further apart than the
-      // configured window are not the same news event regardless of
-      // cosine. Cuts dense-theme false-merges from cross-news-cycle
-      // matches (REQ-PIPE-003).
-      const deltaSeconds = Math.abs(self.published_at - matchPublishedAt);
-      if (deltaSeconds > timeWindowSeconds) {
+      const c = classifyMatchPair(self, match, classifierParams);
+      if (c.kind === 'no_metadata') continue;
+      if (c.kind === 'out_of_window') {
+        // Hard time-window gate — pairs published further apart than
+        // the configured window are not the same news event regardless
+        // of cosine. Cuts dense-theme false-merges from cross-news-
+        // cycle matches (REQ-PIPE-003).
         log('info', 'digest.generation', {
           status: 'historical_dedup_match_skipped_time_window',
           self_id: self.id,
           match_id: match.id,
-          delta_seconds: deltaSeconds,
+          delta_seconds: c.deltaSeconds,
         });
         continue;
       }
-      // High-confidence band (AD40, 2026-05-09): pairs whose RAW
-      // cosine clears `highConfidenceCosine` auto-merge unconditionally,
-      // bypassing the same-vendor penalty. Mirrors the finalize-
-      // consumer behaviour so the per-tick and operator-sweep paths
-      // make consistent decisions on near-duplicate-headline pairs.
-      const isHighConfidence = match.score >= highConfidenceCosine;
-      // Same-vendor cosine penalty (REQ-PIPE-003 AC 11). Subtracts
-      // the configured offset before comparing to the threshold so
-      // same-publisher pairs need a stronger signal than cross-
-      // publisher pairs to merge — neutralises publisher-style
-      // boilerplate inflating cosines on LLM-summary embeddings.
-      // Skipped when the pair is already in the high-confidence band.
-      const matchUrl =
-        typeof meta?.primary_source_url === 'string'
-          ? meta.primary_source_url
-          : '';
-      const sameEtld1 =
-        matchUrl !== '' && sameVendor(self.primary_source_url, matchUrl);
-      const adjustedScore = sameEtld1 && !isHighConfidence
-        ? match.score - sameVendorPenalty
-        : match.score;
       // PASS 2 only handles the strictly-newer direction. Older
-      // matches were the responsibility of PASS 1 above. Equal-time
-      // pairs are tie-broken by ULID (lower ULID = older = wins).
-      if (matchPublishedAt < self.published_at) continue;
-      if (matchPublishedAt === self.published_at && self.id >= match.id)
-        continue;
-      const isAutoMerge = isHighConfidence || adjustedScore >= threshold;
-      const isBorderline =
-        !isAutoMerge && adjustedScore >= rerankFloor;
-      if (!isAutoMerge && !isBorderline) continue;
+      // matches were the responsibility of PASS 1 above. selfIsOlder
+      // already encodes the equal-time ULID tie-break (lower id = older).
+      if (!c.selfIsOlder) continue;
+      const adjustedScore = c.adjustedScore;
+      if (!c.isAutoMerge && !c.isBorderline) continue;
 
       // Confirm the newer article still exists in D1; Vectorize may
       // hold a vector whose D1 row was retention-deleted in the
@@ -334,7 +292,7 @@ export async function runHistoricalDedupBatch(
         .first<{ id: string; title: string; source_snippet: string | null }>();
       if (stillThere === null) continue;
 
-      if (isBorderline) {
+      if (c.isBorderline) {
         // No per-batch rerank cap — the queue consumer has a 15-min
         // wall-clock budget per message; the prior 4-rerank cap was
         // a leftover from the synchronous browser-loop era and was

--- a/src/lib/rate-limit.ts
+++ b/src/lib/rate-limit.ts
@@ -253,6 +253,25 @@ export const RATE_LIMIT_RULES = {
     limit: 5,
     windowSec: 60,
   },
+  // CF-008 — admin force-refresh kicks the whole pipeline (one scrape
+  // tick + finalize + dedup). 5/hour/user comfortably covers an
+  // operator hammering "refresh" through a real session while bounding
+  // accidental loops or compromised-admin abuse.
+  ADMIN_FORCE_REFRESH: {
+    routeClass: 'admin_force_refresh',
+    limit: 5,
+    windowSec: 3600,
+    failClosed: true,
+  },
+  // CF-008 — pipeline-run/wipe is the most expensive admin action
+  // (re-embeds every article). 2/hour/user is enough for legitimate
+  // operator re-runs after a config change while preventing burst abuse.
+  ADMIN_PIPELINE_RUN: {
+    routeClass: 'admin_pipeline_run',
+    limit: 2,
+    windowSec: 3600,
+    failClosed: true,
+  },
   // REQ-SET-007 — POST /api/auth/set-tz writes a single users.tz
   // column. A legitimate user updates this on tz mismatch (rare:
   // travel, DST edge), so 30/min/user is generous — leaves room for

--- a/src/lib/sources.ts
+++ b/src/lib/sources.ts
@@ -39,6 +39,12 @@ const XML_PARSER = new XMLParser({
   ignoreAttributes: false,
   attributeNamePrefix: '',
   trimValues: true,
+  // CF-010: disable HTML entity decoding. The defaults expand &lt;, &amp;,
+  // and numeric entities which could otherwise produce a downstream
+  // XSS vector if a malicious feed re-encoded a payload as a numeric
+  // entity. We treat feed XML as untrusted bytes and let the
+  // sanitizer-on-render path normalize the content instead.
+  processEntities: false,
 });
 
 /**
@@ -57,16 +63,6 @@ export interface SourceAdapter {
   kind: 'json' | 'rss' | 'atom';
   extract: (parsed: unknown) => Headline[];
 }
-
-// CF-022 / E5 — `GENERIC_SOURCES`, `fanOutForTags`, and the three
-// per-source adapters (HACKER_NEWS, GOOGLE_NEWS, REDDIT) were removed
-// alongside the 2026-04-23 global-feed rework. Production resolves
-// every per-tag feed through `adaptersForDiscoveredFeeds` (below),
-// which builds adapters directly from `DiscoveredFeed` records held
-// in KV `sources:{tag}`. The three Algolia/Google/Reddit adapters
-// were never referenced by `adaptersForDiscoveredFeeds` and were
-// pure dead weight after the rework — code-reviewer flagged them
-// as unused-variable lint warnings under `--deny-warnings`.
 
 // ---------- Fetch one source for one tag ---------------------------------
 

--- a/src/middleware/admin-auth.ts
+++ b/src/middleware/admin-auth.ts
@@ -57,6 +57,22 @@ interface AccessJwtClaims {
   exp?: number;
 }
 
+function isAccessJwtClaims(p: unknown): p is AccessJwtClaims {
+  if (typeof p !== 'object' || p === null) return false;
+  const o = p as Record<string, unknown>;
+  if (
+    o['aud'] !== undefined &&
+    typeof o['aud'] !== 'string' &&
+    !Array.isArray(o['aud'])
+  ) {
+    return false;
+  }
+  if (o['email'] !== undefined && typeof o['email'] !== 'string') return false;
+  if (o['sub'] !== undefined && typeof o['sub'] !== 'string') return false;
+  if (o['exp'] !== undefined && typeof o['exp'] !== 'number') return false;
+  return true;
+}
+
 function decodeAccessJwt(jwt: string): AccessJwtClaims | null {
   const parts = jwt.split('.');
   if (parts.length !== 3) return null;
@@ -74,8 +90,15 @@ function decodeAccessJwt(jwt: string): AccessJwtClaims | null {
   } catch {
     return null;
   }
-  if (typeof parsed !== 'object' || parsed === null) return null;
-  return parsed as AccessJwtClaims;
+  if (!isAccessJwtClaims(parsed)) return null;
+  // CF-007-R: reject access tokens whose `exp` is in the past or
+  // missing. Cloudflare Access stamps `exp` on every issued JWT; a
+  // missing field means the token shape is non-standard (synthetic or
+  // tampered) and a past `exp` means a replay attempt with an
+  // expired credential. Either way the JWT must be treated as invalid.
+  const nowSec = Math.floor(Date.now() / 1000);
+  if (typeof parsed.exp !== 'number' || parsed.exp < nowSec) return null;
+  return parsed;
 }
 
 function audMatches(

--- a/src/pages/api/admin/force-refresh.ts
+++ b/src/pages/api/admin/force-refresh.ts
@@ -22,6 +22,15 @@ import { checkOrigin, originOf } from '~/middleware/origin-check';
 import { requireAdminSession } from '~/middleware/admin-auth';
 import { applyRefreshCookie } from '~/middleware/auth';
 import { kickCoordinator } from '~/lib/kick-coordinator';
+import { enforceRateLimit, RATE_LIMIT_RULES } from '~/lib/rate-limit';
+
+/** CF-008 — Build a 429 response body shared between POST + GET paths. */
+function rateLimited(retryAfter: number): Response {
+  return new Response('Too Many Requests', {
+    status: 429,
+    headers: { 'Retry-After': String(retryAfter) },
+  });
+}
 
 function redirectToSettings(origin: string, runId: string, reused: boolean): Response {
   const status = reused ? 'reused' : 'ok';
@@ -46,6 +55,13 @@ export async function POST(context: APIContext): Promise<Response> {
 
   const adminAuth = await requireAdminSession(context);
   if (!adminAuth.ok) return adminAuth.response;
+
+  const rl = await enforceRateLimit(
+    env,
+    RATE_LIMIT_RULES.ADMIN_FORCE_REFRESH,
+    `user:${adminAuth.userId}`,
+  );
+  if (!rl.ok) return rateLimited(rl.retryAfter);
 
   const originResult = checkOrigin(context.request, appOrigin);
   if (!originResult.ok) return originResult.response;
@@ -93,6 +109,19 @@ export async function GET(context: APIContext): Promise<Response> {
     return new Response(null, {
       status: 303,
       headers: { Location: `${appOrigin}/settings?force_refresh=denied` },
+    });
+  }
+
+  const rl = await enforceRateLimit(
+    env,
+    RATE_LIMIT_RULES.ADMIN_FORCE_REFRESH,
+    `user:${adminAuth.userId}`,
+  );
+  if (!rl.ok) {
+    if (wantsJson) return rateLimited(rl.retryAfter);
+    return new Response(null, {
+      status: 303,
+      headers: { Location: `${appOrigin}/settings?force_refresh=rate_limited` },
     });
   }
 

--- a/src/pages/api/admin/pipeline-run.ts
+++ b/src/pages/api/admin/pipeline-run.ts
@@ -44,6 +44,7 @@ import { applyRefreshCookie } from '~/middleware/auth';
 import { checkDevEndpointOrigin, originOf } from '~/middleware/origin-check';
 import { generateUlid } from '~/lib/ulid';
 import { enforceRateLimit, RATE_LIMIT_RULES } from '~/lib/rate-limit';
+import { sanitizeErrorDetail } from '~/lib/error-sanitize';
 import type { PipelinePhase } from '~/queue/pipeline-consumer';
 
 type AdminAuthOk = Extract<AdminAuthResult, { ok: true }>;
@@ -218,7 +219,7 @@ async function runKick(
             WHERE id = ?1
               AND status = 'running'`,
         )
-        .bind(pipelineRunId, now, String(err).slice(0, 500))
+        .bind(pipelineRunId, now, sanitizeErrorDetail(err))
         .run();
     } catch {
       /* swallow */

--- a/src/pages/api/admin/pipeline-run.ts
+++ b/src/pages/api/admin/pipeline-run.ts
@@ -43,6 +43,7 @@ import {
 import { applyRefreshCookie } from '~/middleware/auth';
 import { checkDevEndpointOrigin, originOf } from '~/middleware/origin-check';
 import { generateUlid } from '~/lib/ulid';
+import { enforceRateLimit, RATE_LIMIT_RULES } from '~/lib/rate-limit';
 import type { PipelinePhase } from '~/queue/pipeline-consumer';
 
 type AdminAuthOk = Extract<AdminAuthResult, { ok: true }>;
@@ -84,6 +85,25 @@ export async function POST(context: APIContext): Promise<Response> {
     });
   }
 
+  // CF-008
+  const rl = await enforceRateLimit(
+    env,
+    RATE_LIMIT_RULES.ADMIN_PIPELINE_RUN,
+    `user:${adminAuth.userId}`,
+  );
+  if (!rl.ok) {
+    if (wantsJson) {
+      return new Response('Too Many Requests', {
+        status: 429,
+        headers: { 'Retry-After': String(rl.retryAfter) },
+      });
+    }
+    return new Response(null, {
+      status: 303,
+      headers: { Location: `${appOrigin}/settings?pipeline=rate_limited` },
+    });
+  }
+
   const mode = await parseModeFromBody(context.request);
   return runKick(env, adminAuth, appOrigin, wantsJson, mode);
 }
@@ -110,6 +130,45 @@ export async function GET(context: APIContext): Promise<Response> {
   const url = new URL(context.request.url);
   const requestedMode: 'full' | 'wipe' =
     url.searchParams.get('mode') === 'wipe' ? 'wipe' : 'full';
+
+  // CF-009: `wipe` re-embeds the entire corpus — destructive enough
+  // that we refuse to serve it from a GET. Browser callers must POST
+  // the form; idempotent `full` continues to be reachable via GET
+  // (the post-SSO redirect chain depends on it).
+  if (requestedMode === 'wipe') {
+    if (wantsJson) {
+      return new Response(
+        JSON.stringify({ ok: false, error: 'method_not_allowed' }),
+        {
+          status: 405,
+          headers: { 'Content-Type': 'application/json', Allow: 'POST' },
+        },
+      );
+    }
+    return new Response('Use POST for mode=wipe', {
+      status: 405,
+      headers: { Allow: 'POST' },
+    });
+  }
+
+  // CF-008
+  const rl = await enforceRateLimit(
+    env,
+    RATE_LIMIT_RULES.ADMIN_PIPELINE_RUN,
+    `user:${adminAuth.userId}`,
+  );
+  if (!rl.ok) {
+    if (wantsJson) {
+      return new Response('Too Many Requests', {
+        status: 429,
+        headers: { 'Retry-After': String(rl.retryAfter) },
+      });
+    }
+    return new Response(null, {
+      status: 303,
+      headers: { Location: `${appOrigin}/settings?pipeline=rate_limited` },
+    });
+  }
 
   return runKick(env, adminAuth, appOrigin, wantsJson, requestedMode);
 }

--- a/src/pages/api/dev/login.ts
+++ b/src/pages/api/dev/login.ts
@@ -47,6 +47,15 @@ export async function POST(context: APIContext): Promise<Response> {
   const env = context.locals.runtime.env as typeof context.locals.runtime.env &
     BypassEnv;
 
+  // CF-019-R: hard prod guard. The DEV_BYPASS_TOKEN gate below is
+  // already the primary defence, but a tokenful prod deploy (operator
+  // mistake, accidental secret promotion) must still 404 here so the
+  // bypass surface never opens on news.graymatter.ch.
+  const appUrl = typeof env.APP_URL === 'string' ? env.APP_URL : '';
+  if (appUrl.includes('graymatter.ch')) {
+    return new Response(null, { status: 404 });
+  }
+
   const bypass = env.DEV_BYPASS_TOKEN;
   if (typeof bypass !== 'string' || bypass === '') {
     return new Response(null, { status: 404 });

--- a/src/pages/api/dev/trigger-scrape.ts
+++ b/src/pages/api/dev/trigger-scrape.ts
@@ -38,6 +38,12 @@ export async function POST(context: APIContext): Promise<Response> {
   const env = context.locals.runtime.env as typeof context.locals.runtime.env &
     DevEnv;
 
+  // CF-019-R: hard prod guard, same as /api/dev/login.
+  const appUrl = typeof env.APP_URL === 'string' ? env.APP_URL : '';
+  if (appUrl.includes('graymatter.ch')) {
+    return new Response(null, { status: 404 });
+  }
+
   const bypass = env.DEV_BYPASS_TOKEN;
   if (typeof bypass !== 'string' || bypass === '') {
     return new Response(null, { status: 404 });

--- a/src/queue/cleanup.ts
+++ b/src/queue/cleanup.ts
@@ -77,6 +77,7 @@ export async function runCleanup(env: Env): Promise<{
   stuckTagsPruned: number;
   refreshTokensPurged: number;
   chunkCompletionsPurged: number;
+  orphanScrapeRunsPurged: number;
 }> {
   const articlesDeleted = await runArticleRetention(
     env,
@@ -95,13 +96,50 @@ export async function runCleanup(env: Env): Promise<{
   );
   const refreshTokensPurged = await runRefreshTokenPurge(env);
   const chunkCompletionsPurged = await runChunkCompletionsPurge(env);
+  const orphanScrapeRunsPurged = await runOrphanScrapeRunSweep(env);
   return {
     articlesDeleted,
     orphanTagsDeleted,
     stuckTagsPruned,
     refreshTokensPurged,
     chunkCompletionsPurged,
+    orphanScrapeRunsPurged,
   };
+}
+
+/** CF-018 — fail any scrape_run stuck with `chunk_count = -1` (the
+ *  coordinator dispatch sentinel) for more than 6 hours. A dispatch
+ *  that crashed between the CAS flip and the chunk-count rollback in
+ *  Step 8 leaves the row in the dispatch-claimed state, blocking
+ *  future force-refresh attempts. 6h is well past any legitimate
+ *  in-flight dispatch (chunk consumers exhaust within minutes). */
+async function runOrphanScrapeRunSweep(env: Env): Promise<number> {
+  try {
+    const result = await env.DB
+      .prepare(
+        `UPDATE scrape_runs
+            SET status = 'failed',
+                finalize_recorded = 1
+          WHERE chunk_count = -1
+            AND created_at < unixepoch() - 21600
+            AND status = 'running'`,
+      )
+      .run();
+    const purged = result.meta?.changes ?? 0;
+    if (purged > 0) {
+      log('warn', 'digest.generation', {
+        status: 'cleanup_orphan_scrape_runs_purged',
+        purged,
+      });
+    }
+    return purged;
+  } catch (err) {
+    log('error', 'digest.generation', {
+      status: 'cleanup_orphan_scrape_runs_failed',
+      detail: errMsg(err),
+    });
+    return 0;
+  }
 }
 
 /** CF-008 — delete `scrape_chunk_completions` rows for runs whose

--- a/src/queue/pipeline-consumer.ts
+++ b/src/queue/pipeline-consumer.ts
@@ -83,6 +83,11 @@ interface PipelineRunRow {
  *  without hammering D1. */
 const WAIT_DELAY_SECONDS = 10;
 
+/** CF-001: maximum number of times scrape_wait may re-enqueue itself
+ *  before flagging the pipeline run as stalled and forcing a failed
+ *  exit. 12 × 10s = ~2 minutes of waiting on a stuck finalize gate. */
+const SCRAPE_WAIT_MAX_ITERATIONS = 12;
+
 /** Cumulative-articles ceiling for embed-drain self-chain. Guards
  *  against a runaway loop spinning forever on a corrupt corpus.
  *  10k matches the operational corpus ceiling; raise both this and
@@ -261,10 +266,18 @@ async function runScrapeWait(env: Env, run: PipelineRunRow): Promise<void> {
   }
   const row = await env.DB
     .prepare(
-      `SELECT status, finalize_recorded FROM scrape_runs WHERE id = ?1`,
+      `SELECT status, finalize_recorded, wait_iterations FROM scrape_runs WHERE id = ?1`,
     )
     .bind(run.scrape_run_id)
-    .first<{ status: string; finalize_recorded: number }>();
+    .first<{ status: string; finalize_recorded: number; wait_iterations: number }>();
+
+  // CF-001: failed status exits the wait loop immediately regardless
+  // of finalize_recorded — a failed scrape never records finalize and
+  // would otherwise re-enqueue forever.
+  if (row !== null && row.status === 'failed') {
+    await markFailed(env, run.id, 'scrape_failed');
+    return;
+  }
 
   // Advance once both: scrape_runs.status != 'running' AND finalize
   // has been recorded (the finalize-consumer is the last writer of
@@ -275,6 +288,39 @@ async function runScrapeWait(env: Env, run: PipelineRunRow): Promise<void> {
     row.finalize_recorded === 1;
 
   if (!scrapeReady) {
+    // CF-001: bump wait_iterations; if it exceeds the cap, force-fail
+    // the underlying scrape_run instead of re-enqueuing. The cap fires
+    // when finalize is stuck (queue saturation, DLQ trip, or a bug in
+    // the finalize consumer not flipping the gate).
+    const iters = (row?.wait_iterations ?? 0) + 1;
+    if (run.scrape_run_id !== null && iters > SCRAPE_WAIT_MAX_ITERATIONS) {
+      await env.DB
+        .prepare(
+          `UPDATE scrape_runs
+              SET status = 'failed',
+                  finalize_recorded = 1,
+                  wait_iterations = ?2
+            WHERE id = ?1`,
+        )
+        .bind(run.scrape_run_id, iters)
+        .run()
+        .catch(() => {});
+      log('error', 'digest.generation', {
+        status: 'pipeline_scrape_wait_capped',
+        pipeline_run_id: run.id,
+        scrape_run_id: run.scrape_run_id,
+        wait_iterations: iters,
+      });
+      await markFailed(env, run.id, 'scrape_wait_stalled');
+      return;
+    }
+    if (run.scrape_run_id !== null) {
+      await env.DB
+        .prepare(`UPDATE scrape_runs SET wait_iterations = ?2 WHERE id = ?1`)
+        .bind(run.scrape_run_id, iters)
+        .run()
+        .catch(() => {});
+    }
     await env.PIPELINE_JOBS.send(
       { pipeline_run_id: run.id, phase: 'scrape_wait' },
       { delaySeconds: WAIT_DELAY_SECONDS },
@@ -286,12 +332,8 @@ async function runScrapeWait(env: Env, run: PipelineRunRow): Promise<void> {
       scrape_run_id: run.scrape_run_id,
       scrape_status: row?.status ?? 'missing',
       finalize_recorded: row?.finalize_recorded ?? 0,
+      wait_iterations: iters,
     });
-    return;
-  }
-
-  if (row.status === 'failed') {
-    await markFailed(env, run.id, 'scrape_failed');
     return;
   }
 

--- a/src/queue/scrape-chunk-consumer.ts
+++ b/src/queue/scrape-chunk-consumer.ts
@@ -876,8 +876,6 @@ async function recordChunkCompletionAndCheckFinalize(
   return { isFirstCompletion, completedCount };
 }
 
-// titlesShareAnyToken / tokenizeTitle moved to ~/lib/title-overlap (CF-058).
-
 /** Load the tag allowlist: DEFAULT_HASHTAGS ∪ any tag whose
  * `sources:{tag}` KV key exists. De-duplicated, lowercase, no leading `#`. */
 async function loadAllowedTags(kv: KVNamespace): Promise<string[]> {

--- a/src/queue/scrape-chunk-consumer.ts
+++ b/src/queue/scrape-chunk-consumer.ts
@@ -141,6 +141,16 @@ export async function handleChunkBatch(
       const completed = await countChunkCompletions(env.DB, body.scrape_run_id);
       const finalStatus: 'ready' | 'failed' = completed > 0 ? 'ready' : 'failed';
       await finishRun(env.DB, body.scrape_run_id, finalStatus);
+      if (finalStatus === 'failed') {
+        // CF-001: no finalize will run for this scrape_run; stamp the
+        // gate so runScrapeWait sees a terminal state and the pipeline
+        // exits via the failed-status check.
+        await env.DB
+          .prepare(`UPDATE scrape_runs SET finalize_recorded = 1 WHERE id = ?1`)
+          .bind(body.scrape_run_id)
+          .run()
+          .catch(() => {});
+      }
       if (finalStatus === 'ready') {
         // Enqueue finalize so cross-chunk dedup runs over the chunks
         // that did complete. Same atomic-lock pattern as the

--- a/src/queue/scrape-chunk-consumer.ts
+++ b/src/queue/scrape-chunk-consumer.ts
@@ -110,6 +110,12 @@ interface LLMChunkPayload {
   dedup_groups?: unknown;
 }
 
+/** CF-021: cap on `detail` substrings in structured logs. 500 chars is
+ *  comfortably larger than any single-line error class name + message
+ *  while staying under the per-line log retention budget that
+ *  `wrangler tail` sustains under load. */
+const LOG_PAYLOAD_MAX_CHARS = 500;
+
 /** Handle one batch of `scrape-chunks` messages. Delegates the per-
  * message try/ack/retry/terminal-failure pattern to the shared
  * `handleBatch` envelope. */
@@ -149,7 +155,13 @@ export async function handleChunkBatch(
           .prepare(`UPDATE scrape_runs SET finalize_recorded = 1 WHERE id = ?1`)
           .bind(body.scrape_run_id)
           .run()
-          .catch(() => {});
+          .catch((stampErr) => {
+            log('warn', 'digest.generation', {
+              status: 'terminal_failure_finalize_recorded_stamp_failed',
+              scrape_run_id: body.scrape_run_id,
+              detail: String(stampErr).slice(0, LOG_PAYLOAD_MAX_CHARS),
+            });
+          });
       }
       if (finalStatus === 'ready') {
         // Enqueue finalize so cross-chunk dedup runs over the chunks
@@ -171,12 +183,22 @@ export async function handleChunkBatch(
               )
               .bind(body.scrape_run_id)
               .run()
-              .catch(() => {});
+              .catch((rollbackErr) => {
+                // CF-022: surface the rollback failure instead of
+                // swallowing — without this log the run is silently
+                // stuck with finalize_enqueued=1 and no consumer.
+                log('warn', 'digest.generation', {
+                  status: 'partial_finalize_enqueue_rollback_failed',
+                  scrape_run_id: body.scrape_run_id,
+                  chunk_index: body.chunk_index,
+                  detail: String(rollbackErr).slice(0, LOG_PAYLOAD_MAX_CHARS),
+                });
+              });
             log('error', 'digest.generation', {
               status: 'partial_finalize_enqueue_failed',
               scrape_run_id: body.scrape_run_id,
               chunk_index: body.chunk_index,
-              detail: String(sendErr).slice(0, 500),
+              detail: String(sendErr).slice(0, LOG_PAYLOAD_MAX_CHARS),
             });
           }
         }
@@ -279,7 +301,7 @@ export async function processOneChunk(
   } = alignLlmArticlesToInputs(rawArticles, perInputClusters, mergedClusters, dedupGroups, body);
 
   // Validate + sanitize each survivor; drop articles that fail any gate.
-  const prepared: PreparedArticle[] = [];
+  let prepared: PreparedArticle[] = [];
   for (const s of survivors) {
     const article = validateAndSanitizeArticle(s, allowedTagSet, body);
     if (article !== null) prepared.push(article);
@@ -290,7 +312,7 @@ export async function processOneChunk(
   // failure, articles stay at the validateAndSanitizeArticle default
   // ('failed', null vector) and the admin backfill route picks them
   // up later. REQ-PIPE-003.
-  await attachEmbeddings(env, prepared, body);
+  prepared = await attachEmbeddings(env, prepared, body);
 
   // Write articles + sources + tags in a single atomic D1 batch.
   const statements = buildArticleBatchStatements(env.DB, prepared, body.scrape_run_id);
@@ -842,8 +864,8 @@ async function recordChunkCompletionAndCheckFinalize(
           log('error', 'digest.generation', {
             status: 'finalize_lock_rollback_failed',
             scrape_run_id: body.scrape_run_id,
-            send_error: String(sendErr).slice(0, 500),
-            rollback_error: String(rollbackErr).slice(0, 500),
+            send_error: String(sendErr).slice(0, LOG_PAYLOAD_MAX_CHARS),
+            rollback_error: String(rollbackErr).slice(0, LOG_PAYLOAD_MAX_CHARS),
           });
         }
         throw sendErr;
@@ -964,8 +986,8 @@ async function attachEmbeddings(
   env: Env,
   prepared: PreparedArticle[],
   body: ChunkJobMessage,
-): Promise<void> {
-  if (prepared.length === 0) return;
+): Promise<PreparedArticle[]> {
+  if (prepared.length === 0) return prepared;
   const inputs = prepared.map((a) =>
     buildEmbeddingInput({
       title: a.title,
@@ -981,27 +1003,30 @@ async function attachEmbeddings(
       );
     }
     const nowSec = Math.floor(Date.now() / 1000);
-    for (let i = 0; i < prepared.length; i++) {
-      const article = prepared[i];
+    return prepared.map((article, i) => {
       const vector = vectors[i];
-      if (article === undefined || vector === undefined) continue;
-      article.embedding_status = 'embedded';
-      article.embedded_at = nowSec;
-      article.embedding = vector;
-    }
+      if (vector === undefined) return article;
+      return {
+        ...article,
+        embedding_status: 'embedded' as const,
+        embedded_at: nowSec,
+        embedding: vector,
+      };
+    });
   } catch (err) {
-    for (const article of prepared) {
-      article.embedding_status = 'failed';
-      article.embedded_at = null;
-      article.embedding = null;
-    }
     log('warn', 'digest.generation', {
       status: 'chunk_embed_failed',
       scrape_run_id: body.scrape_run_id,
       chunk_index: body.chunk_index,
       article_count: prepared.length,
-      detail: String(err).slice(0, 500),
+      detail: String(err).slice(0, LOG_PAYLOAD_MAX_CHARS),
     });
+    return prepared.map((article) => ({
+      ...article,
+      embedding_status: 'failed' as const,
+      embedded_at: null,
+      embedding: null,
+    }));
   }
 }
 
@@ -1054,7 +1079,7 @@ async function upsertVectors(
       scrape_run_id: body.scrape_run_id,
       chunk_index: body.chunk_index,
       vector_count: embedded.length,
-      detail: String(err).slice(0, 500),
+      detail: String(err).slice(0, LOG_PAYLOAD_MAX_CHARS),
     });
     try {
       // Gate the rollback on the per-attempt embedded_at timestamp.
@@ -1087,7 +1112,7 @@ async function upsertVectors(
         status: 'chunk_vectorize_status_rollback_failed',
         scrape_run_id: body.scrape_run_id,
         chunk_index: body.chunk_index,
-        detail: String(rollbackErr).slice(0, 500),
+        detail: String(rollbackErr).slice(0, LOG_PAYLOAD_MAX_CHARS),
       });
     }
   }

--- a/src/queue/scrape-coordinator.ts
+++ b/src/queue/scrape-coordinator.ts
@@ -301,6 +301,13 @@ export async function runCoordinator(
   // Step 6 — empty-pool guard.
   if (survivors.length === 0) {
     await finishRun(env.DB, scrape_run_id, 'ready');
+    // CF-001: with no survivors there is no finalize tick to flip the
+    // gate, so stamp it here. Otherwise runScrapeWait would loop forever
+    // waiting on a finalize that will never run.
+    await env.DB
+      .prepare(`UPDATE scrape_runs SET finalize_recorded = 1 WHERE id = ?1`)
+      .bind(scrape_run_id)
+      .run();
     log('info', 'digest.generation', { status: 'coordinator_empty_pool', scrape_run_id });
     return;
   }

--- a/src/queue/scrape-finalize-consumer.ts
+++ b/src/queue/scrape-finalize-consumer.ts
@@ -51,7 +51,7 @@ import {
   deleteVectorsBatched,
 } from '~/lib/embeddings';
 import { readRerankFloor, rerankBorderlinePair } from '~/lib/dedup-rerank';
-import { sameVendor } from '~/lib/etld';
+import { classifyMatchPair } from '~/lib/bidirectional-dedup';
 import { generateUlid } from '~/lib/ulid';
 
 /** Hard cap on candidates per finalize call. Comfortable headroom over
@@ -315,6 +315,13 @@ export async function processOneFinalize(
     let bestCosineRaw = 0;
     let bestCosineAdjusted = 0;
 
+    const classifierParams = {
+      threshold,
+      sameVendorPenalty,
+      rerankFloor,
+      timeWindowSeconds,
+      highConfidenceCosine,
+    };
     for (const match of matches) {
       if (match.id === self.id) continue;
       // A candidate already absorbed by a prior iteration of this same
@@ -325,95 +332,61 @@ export async function processOneFinalize(
         continue;
       }
       candidatesSeen += 1;
-      const meta = match.metadata as
-        | { published_at?: unknown; primary_source_url?: unknown }
-        | undefined;
-      const matchPublishedAt =
-        typeof meta?.published_at === 'number' ? meta.published_at : null;
-      if (matchPublishedAt === null) continue;
-      // Hard time-window gate — pairs further apart than the configured
-      // window are not the same news event regardless of how high the
-      // cosine score is. Cuts dense-theme false-merges (e.g. "AI agent
-      // governance") that score above the cosine ceiling on topical
-      // overlap alone. Applied BEFORE same-vendor penalty + threshold.
-      const deltaSeconds = Math.abs(self.published_at - matchPublishedAt);
-      if (deltaSeconds > timeWindowSeconds) {
+      const c = classifyMatchPair(self, match, classifierParams);
+      if (c.kind === 'no_metadata') continue;
+      if (c.kind === 'out_of_window') {
+        // Hard time-window gate — pairs further apart than the configured
+        // window are not the same news event regardless of how high the
+        // cosine score is. Cuts dense-theme false-merges (e.g. "AI agent
+        // governance") that score above the cosine ceiling on topical
+        // overlap alone. Applied BEFORE same-vendor penalty + threshold.
         candidatesSkippedTimeWindow += 1;
         log('info', 'digest.generation', {
           status: 'finalize_match_skipped_time_window',
           scrape_run_id: body.scrape_run_id,
           self_id: self.id,
           match_id: match.id,
-          delta_seconds: deltaSeconds,
+          delta_seconds: c.deltaSeconds,
         });
         continue;
       }
-      // High-confidence band (AD40, 2026-05-09): pairs whose RAW
-      // cosine clears `highConfidenceCosine` auto-merge unconditionally,
-      // bypassing the same-vendor penalty. At raw >= 0.92 the articles
-      // are essentially restating each other (wire-syndicated stories,
-      // near-identical headlines) and the penalty would otherwise drop
-      // genuine duplicates into the rerank band where an LLM
-      // hallucination can reject them.
-      const isHighConfidence = match.score >= highConfidenceCosine;
-      // Apply the same-vendor cosine penalty BEFORE the threshold gate
-      // (skipped for high-confidence pairs). Same-publisher pairs
-      // (cloud.google.com vs blog.google, workos.com vs blog.workos.com)
-      // consistently produced inflated cosines on LLM-summary
-      // embeddings because the model carried publisher-style
-      // boilerplate; the offset neutralises that without forbidding
-      // genuine same-publisher merges.
-      const matchUrl =
-        typeof meta?.primary_source_url === 'string'
-          ? meta.primary_source_url
-          : '';
-      const sameEtld1 =
-        matchUrl !== '' && sameVendor(self.primary_source_url, matchUrl);
-      const adjustedScore = sameEtld1 && !isHighConfidence
-        ? match.score - sameVendorPenalty
-        : match.score;
-      // Direction. self_is_older means self IS the older article in
-      // the pair — the cluster anchors at self and we'd absorb match
-      // INTO self. self_is_older=false means match is older — self
-      // folds into match (the pre-2026-05-09 direction). Equal
-      // `published_at` is tie-broken by ULID; lower id = older. The
-      // strict-older branches below reject the impossible self.id ===
-      // match.id case (already filtered above).
-      const selfIsOlder =
-        self.published_at < matchPublishedAt ||
-        (self.published_at === matchPublishedAt && self.id < match.id);
-      if (selfIsOlder) {
+      // Direction. selfIsOlder=true means self IS the older article
+      // in the pair — the cluster anchors at self and we'd absorb match
+      // INTO self. selfIsOlder=false means match is older — self folds
+      // into match (the pre-2026-05-09 direction). Equal `published_at`
+      // is tie-broken by ULID; lower id = older.
+      if (c.selfIsOlder) {
         candidatesSelfOlder += 1;
       } else {
         candidatesSelfNewer += 1;
       }
-      if (adjustedScore > bestCosineAdjusted) {
+      if (c.adjustedScore > bestCosineAdjusted) {
         bestCosineRaw = match.score;
-        bestCosineAdjusted = adjustedScore;
+        bestCosineAdjusted = c.adjustedScore;
       }
-      if (isHighConfidence) candidatesHighConfidence += 1;
-      if (isHighConfidence || adjustedScore >= threshold) {
+      if (c.isHighConfidence) candidatesHighConfidence += 1;
+      if (c.isAutoMerge) {
         candidatesAboveThreshold += 1;
         candidatesAboveFloor += 1;
         const cand: AutoCandidate = {
           matchId: match.id,
-          matchPublishedAt,
-          adjustedScore,
-          selfIsOlder,
+          matchPublishedAt: c.matchPublishedAt,
+          adjustedScore: c.adjustedScore,
+          selfIsOlder: c.selfIsOlder,
         };
         if (isBetterAutoCandidate(cand, bestAuto)) {
           bestAuto = cand;
         }
-      } else if (adjustedScore >= rerankFloor) {
+      } else if (c.isBorderline) {
         candidatesAboveFloor += 1;
         // Push EVERY borderline candidate into the list. The rerank
         // pass below sorts by `isBetterBorderCandidate` and walks
         // top-down, taking the first LLM=yes verdict.
         borderCandidates.push({
           matchId: match.id,
-          matchPublishedAt,
-          adjustedScore,
-          selfIsOlder,
+          matchPublishedAt: c.matchPublishedAt,
+          adjustedScore: c.adjustedScore,
+          selfIsOlder: c.selfIsOlder,
         });
       }
     }

--- a/tests/lib/historical-dedup-batch.test.ts
+++ b/tests/lib/historical-dedup-batch.test.ts
@@ -136,9 +136,13 @@ function makeDb(fixture: DbFixture): D1Database {
 function makeVectorize(opts: {
   queryByIdResults?: Record<string, VectorizeMatches>;
   deleteByIdsFails?: boolean;
+  queryByIdAllFail?: boolean;
 }): Vectorize {
   return {
     queryById: vi.fn().mockImplementation(async (id: string) => {
+      if (opts.queryByIdAllFail) {
+        throw new Error('Vectorize service unavailable');
+      }
       const result = opts.queryByIdResults?.[id];
       return result ?? { count: 0, matches: [] };
     }),
@@ -159,6 +163,7 @@ interface CallOpts {
   remainingCount?: number;
   queryByIdResults?: Record<string, VectorizeMatches>;
   deleteByIdsFails?: boolean;
+  queryByIdAllFail?: boolean;
   cursor?: { pa: number; id: string } | null;
   batch?: number;
   aiRun?: (model: string, params: Record<string, unknown>) => Promise<unknown>;
@@ -183,6 +188,7 @@ async function callBatch(opts: CallOpts) {
   const vectorize = makeVectorize({
     queryByIdResults: opts.queryByIdResults ?? {},
     deleteByIdsFails: opts.deleteByIdsFails ?? false,
+    queryByIdAllFail: opts.queryByIdAllFail ?? false,
   });
   const aiRun =
     opts.aiRun ??
@@ -838,6 +844,100 @@ describe('runHistoricalDedupBatch — REQ-PIPE-003', () => {
     expect(result.merged).toBe(0);
     expect(fixture.batchCalls.length).toBe(0);
     expect(vectorize.deleteByIds).not.toHaveBeenCalled();
+  });
+
+  it('REQ-PIPE-003 / CF-004: total Vectorize outage returns done:false with input cursor preserved', async () => {
+    // CF-004 (AD45). When every Vectorize.queryById in the batch
+    // throws, the prior implementation silently advanced the cursor
+    // past every failed self, leaving cross-tick duplicates unmerged
+    // once Vectorize recovered. The aligned behavior (mirroring
+    // scrape-finalize-consumer) keeps the cursor at the input position
+    // and reports `done: false` so the queue-driven sweep self-chains
+    // a retry instead of skipping the range.
+    const INPUT_CURSOR = { pa: 1_700_000_000, id: 'cursor-anchor' };
+    const SELF_A = 'self-a';
+    const SELF_B = 'self-b';
+    const { result, vectorize, fixture } = await callBatch({
+      articles: [
+        {
+          id: SELF_A,
+          published_at: 1_700_000_100,
+          primary_source_url: 'https://acme.example/a',
+        },
+        {
+          id: SELF_B,
+          published_at: 1_700_000_200,
+          primary_source_url: 'https://acme.example/b',
+        },
+      ],
+      cursor: INPUT_CURSOR,
+      queryByIdAllFail: true,
+    });
+    expect(result.done).toBe(false);
+    expect(result.merged).toBe(0);
+    expect(result.next_cursor).toEqual(INPUT_CURSOR);
+    expect(result.remaining).toBe(2);
+    expect(result.scanned).toBe(2);
+    // Both rows were attempted; both failed; no merges issued; no
+    // Vectorize.deleteByIds calls (no removedIds to delete).
+    const queryById = vectorize.queryById as ReturnType<typeof vi.fn>;
+    expect(queryById).toHaveBeenCalledTimes(2);
+    expect(fixture.batchCalls.length).toBe(0);
+    const deleteByIds = vectorize.deleteByIds as ReturnType<typeof vi.fn>;
+    expect(deleteByIds).not.toHaveBeenCalled();
+  });
+
+  it('REQ-PIPE-003 / CF-004: partial Vectorize outage still advances cursor (only TOTAL outage halts)', async () => {
+    // If at least one queryById succeeds, we're not in a corpus-wide
+    // outage — the cursor advances normally and `done` reflects the
+    // remaining-count query. This boundary case is what distinguishes
+    // CF-004's gate from "any failure halts the batch."
+    const SELF_OK = 'self-ok';
+    const SELF_FAIL = 'self-fail';
+    const queryByIdMock = vi
+      .fn()
+      .mockImplementationOnce(async () => ({ count: 0, matches: [] }))
+      .mockImplementationOnce(async () => {
+        throw new Error('Vectorize timeout');
+      });
+    const fixture: DbFixture = {
+      articles: [
+        {
+          id: SELF_OK,
+          published_at: 1_700_000_100,
+          primary_source_url: 'https://acme.example/a',
+        },
+        {
+          id: SELF_FAIL,
+          published_at: 1_700_000_200,
+          primary_source_url: 'https://acme.example/b',
+        },
+      ],
+      existenceGuardResults: {},
+      remainingCount: 0,
+      batchCalls: [],
+      allCalls: [],
+    };
+    const db = makeDb(fixture);
+    const vectorize = {
+      queryById: queryByIdMock,
+      deleteByIds: vi.fn().mockResolvedValue({ count: 0, ids: [] }),
+      query: vi.fn(),
+      upsert: vi.fn(),
+    } as unknown as Vectorize;
+    const env = {
+      DB: db,
+      VECTORIZE: vectorize,
+      AI: { run: vi.fn().mockResolvedValue({ response: '{"same_event":false}' }) },
+    } as unknown as Env;
+    const result = await runHistoricalDedupBatch(env, null, 100);
+    // Cursor advanced past both rows (last row is SELF_FAIL).
+    expect(result.done).toBe(true);
+    expect(result.next_cursor).toEqual({
+      pa: 1_700_000_200,
+      id: SELF_FAIL,
+    });
+    expect(queryByIdMock).toHaveBeenCalledTimes(2);
   });
 
   it('REQ-PIPE-009: cosine below floor does not invoke LLM', async () => {

--- a/tests/middleware/admin-auth.test.ts
+++ b/tests/middleware/admin-auth.test.ts
@@ -18,7 +18,11 @@ const ADMIN_EMAIL = 'admin@example.com';
 function makeAccessJwt(claims: Record<string, unknown>): string {
   const enc = new TextEncoder();
   const headerB64 = base64UrlEncode(enc.encode(JSON.stringify({ alg: 'RS256' })));
-  const payloadB64 = base64UrlEncode(enc.encode(JSON.stringify(claims)));
+  // CF-007-R: decodeAccessJwt now validates `exp`. Default to a future
+  // expiry so existing tests stay green; callers exercising the
+  // expired-token path pass an explicit `exp` claim that overrides this.
+  const withExp = { exp: Math.floor(Date.now() / 1000) + 600, ...claims };
+  const payloadB64 = base64UrlEncode(enc.encode(JSON.stringify(withExp)));
   // Signature is opaque to the decoder (we never verify it in-Worker —
   // Cloudflare Access already verified before forwarding).
   return `${headerB64}.${payloadB64}.signature`;

--- a/tests/pipeline/finalize-vectorize.test.ts
+++ b/tests/pipeline/finalize-vectorize.test.ts
@@ -1390,4 +1390,44 @@ describe('processOneFinalize — REQ-PIPE-003', () => {
 
     logSpy.mockRestore();
   });
+
+  it('REQ-PIPE-003 / CF-004: total Vectorize.queryById outage throws (queue retry)', async () => {
+    // CF-004 (AD45). When every Vectorize.queryById fails, the
+    // finalize gate stays un-flipped and the consumer rejects so the
+    // queue retry path covers Vectorize recovery. Historical-dedup now
+    // mirrors this behavior (returns done:false with cursor preserved);
+    // this test pins the finalize side of the contract.
+    const SELF_ID = 'survivor-1';
+    const mockDb = makeMockDb({
+      articleRows: [
+        {
+          id: SELF_ID,
+          published_at: 1_700_000_100,
+          ingested_at: 1_700_000_100,
+          primary_source_url: 'https://acme.example/a',
+        },
+      ],
+    });
+    const queryByIdMock = vi.fn().mockImplementation(async () => {
+      throw new Error('Vectorize service unavailable');
+    });
+    const vectorize: Vectorize = {
+      queryById: queryByIdMock,
+      query: vi.fn(),
+      upsert: vi.fn(),
+      deleteByIds: vi.fn().mockResolvedValue({ count: 0, ids: [] }),
+    } as unknown as Vectorize;
+    const env = makeEnv(mockDb.db, vectorize);
+
+    await expect(
+      processOneFinalize(env, { scrape_run_id: 'r1' }),
+    ).rejects.toThrow();
+    // The gate row must NOT have been UPDATEd to finalize_recorded=1.
+    const gateFlip = mockDb.calls.find(
+      (c) =>
+        c.sql.includes('UPDATE scrape_runs') &&
+        c.sql.includes('finalize_recorded = 1'),
+    );
+    expect(gateFlip).toBeUndefined();
+  });
 });

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -188,6 +188,9 @@ DEDUP_HIGH_CONFIDENCE_COSINE = "0.92"
 name = "ai-news-digest-integration"
 main = "./dist/_worker.js/_merged.mjs"
 assets = { directory = "./dist", binding = "ASSETS" }
+# CF-027: mirror the top-level workers_dev=false so the integration
+# deploy never accidentally exposes a *.workers.dev hostname.
+workers_dev = false
 
 [env.integration.vars]
 # CF-004 — must match the top-level [vars] QUEUE_MAX_RETRIES; the


### PR DESCRIPTION
## Summary

Cycle-1 review bundle from /review --verify-high (2026-05-11). Lands all 27 fixes against develop. Drafted while in progress so CI runs on each commit.

Triage report: `/home/user/Temporary/Review/20260511-110216/11-triage-results.md`
Plan: 8 commits, dependency-ordered.

## Commits landed so far

- **CF-004** (Vectorize-outage alignment): historical-dedup batch loop now preserves cursor + returns done:false when every queryById fails, matching scrape-finalize-consumer's outage gate semantics.
- **CF-001, CF-018** (pipeline state machine): failed-status exits scrape_wait, wait_iterations cap (12 ticks ~2min), empty-pool + terminal-failed paths flip finalize_recorded, daily cron cleans orphan dispatch sentinels, DLQ queue provisioning in deploy workflows.

## Coming up

- CF-002/005/029 - bidirectional-dedup module extraction + finalize continuation pagination (replaces FINALIZE_CANDIDATE_CAP truncation).
- CF-015/021/022/030 - immutable attachEmbeddings, silent-catch fix, magic-number hoist, crypto safety comment.
- CF-007R/008/009/019R/014 - admin auth hardening (JWT exp validation, admin rate limits, GET to POST for wipe, dev-route prod guard, callback extraction).
- CF-012/013R/024 - test discipline (replace text-matching theater, brittle indices, dedup test gaps).
- CF-010/011/016/023/027/028/032 - chore (XML config, dead exports, wrangler parity CI step, tombstone removal, error sanitization, ADR Status fields).
- spec + changelog + AD43/AD44.

## Test plan

- [ ] CI ALL GREEN on every commit
- [ ] No new .skip without inline justification
- [ ] After merge to develop, user opens develop to main PR where SDD review pipeline fires
