### PR TITLE
fix(auth): resolve H1 (CSRF constant-time) + H2/M1 (cookie-clear test pins) from cycle-1 review

### DIFF
--- a/src/lib/crypto.ts
+++ b/src/lib/crypto.ts
@@ -109,35 +109,6 @@ export async function verifyHmacSignature(
 }
 
 /**
- * Constant-time byte-equality on two strings of equal length.
- *
- * Returns false when the lengths differ (the length check is itself
- * unsafe to expose timing on, but length is not a secret - the
- * CSRF-state cookie values this helper compares are public-shape
- * tokens whose byte length is fixed by `oauthStateCookieName`).
- *
- * Implementation: XOR-accumulate over the full length of both strings
- * so the loop time depends only on the input length, not on the
- * position of the first differing byte. The accumulator is then
- * checked against zero in a single equality test.
- *
- * Used in `src/pages/api/auth/[provider]/callback.ts` for the OAuth
- * CSRF state cookie vs. query-param byte equality check (CF-011) -
- * the cookie value is set by the worker itself, so HMAC verification
- * adds no security over plain byte equality there. The
- * {@link verifyHmacSignature} helper remains the correct primitive
- * when the candidate is HMAC-signed input (e.g. dev-bypass tokens).
- */
-export function constantTimeEq(expected: string, candidate: string): boolean {
-  if (expected.length !== candidate.length) return false;
-  let diff = 0;
-  for (let i = 0; i < expected.length; i++) {
-    diff |= expected.charCodeAt(i) ^ candidate.charCodeAt(i);
-  }
-  return diff === 0;
-}
-
-/**
  * Hex-encode a Uint8Array. Lowercase, no separator. Used by the
  * refresh-token module for cookie values + SHA-256 digests.
  */

--- a/src/pages/api/auth/[provider]/callback.ts
+++ b/src/pages/api/auth/[provider]/callback.ts
@@ -47,7 +47,7 @@ import {
   oauthStateCookieName,
   buildClearOAuthStateCookie,
 } from './login';
-import { readCookie, constantTimeEq } from '~/lib/crypto';
+import { readCookie, verifyHmacSignature } from '~/lib/crypto';
 import { enforceRateLimit, rateLimitResponse, clientIp, RATE_LIMIT_RULES } from '~/lib/rate-limit';
 
 interface TokenResponse {
@@ -131,12 +131,12 @@ function invalidStateResponse(origin: string, extraHeaders: Headers): Response {
 // `escapeHtml` from `~/lib/email-html`, which covers the same five
 // special characters and is already used by the email renderer.
 
-// CSRF state byte-equality uses `constantTimeEq` from `~/lib/crypto`
-// (CF-011 - previously used `verifyHmacSignature` against the cookie
-// value, but the cookie is set by the worker itself, so plain constant-
-// time byte equality is the right primitive). `verifyHmacSignature` is
-// still the correct helper when comparing against an HMAC-signed input
-// (dev-bypass tokens in dev/login.ts and dev/trigger-scrape.ts).
+// CSRF state byte-equality uses `verifyHmacSignature` from `~/lib/crypto`,
+// which routes through `crypto.subtle.verify` (constant-time by Web
+// Crypto spec). A JS XOR-accumulate loop is not a guaranteed constant-
+// time primitive under V8 JIT optimisation, so the Web Crypto path is
+// the only correct primitive for security-sensitive byte equality even
+// when the candidate is server-issued (cookie value).
 
 /**
  * Exchange an authorization code for the provider's token response.
@@ -322,10 +322,10 @@ function step2HandleProviderError(
  * AC 3). Uses constant-time byte equality. On mismatch returns a 403
  * with the state cookie cleared.
  */
-function step3VerifyCsrfState(
+async function step3VerifyCsrfState(
   context: APIContext,
   state: ResolvedState,
-): StepResult<ResolvedState> {
+): Promise<StepResult<ResolvedState>> {
   const stateCookieName = oauthStateCookieName(state.provider.name);
   const queryState = state.url.searchParams.get('state');
   const cookieHeader = context.request.headers.get('Cookie');
@@ -335,7 +335,7 @@ function step3VerifyCsrfState(
     queryState !== '' &&
     cookieState !== null &&
     cookieState !== '' &&
-    constantTimeEq(cookieState, queryState);
+    (await verifyHmacSignature(cookieState, queryState, state.env.OAUTH_JWT_SECRET));
   if (!statesMatch) {
     log('warn', 'auth.callback.invalid_state', {
       provider: state.provider.name,
@@ -667,7 +667,7 @@ export async function GET(context: APIContext): Promise<Response> {
   const r2 = step2HandleProviderError(context, r1.value);
   if (r2.kind === 'respond') return r2.response;
 
-  const r3 = step3VerifyCsrfState(context, r2.value);
+  const r3 = await step3VerifyCsrfState(context, r2.value);
   if (r3.kind === 'respond') return r3.response;
 
   const r4 = await step4ExchangeCodeAndFetchProfile(r3.value);

--- a/tests/auth/middleware.test.ts
+++ b/tests/auth/middleware.test.ts
@@ -464,8 +464,11 @@ describe('loadSessionForPage - REQ-AUTH-002 / REQ-AUTH-008', () => {
     // Both Set-Cookie strings are now on the page response headers.
     const h = responseHeaders as Headers & { getSetCookie?: () => string[] };
     const cookies = typeof h.getSetCookie === 'function' ? h.getSetCookie() : [];
-    expect(cookies.length).toBeGreaterThan(0);
+    // Both cookies must clear — pinned to exact count so a regression
+    // dropping the refresh-clear is caught.
+    expect(cookies.length).toBe(2);
     expect(cookies.some((c) => c.startsWith(`${SESSION_COOKIE_NAME}=;`))).toBe(true);
+    expect(cookies.some((c) => c.startsWith('__Host-news_digest_refresh=;'))).toBe(true);
     // Returned array mirrors the headers so callers can paint a separate
     // gated-redirect Response if they need to.
     expect(result.cookiesToSet.length).toBe(cookies.length);

--- a/tests/auth/refresh-tokens.test.ts
+++ b/tests/auth/refresh-tokens.test.ts
@@ -443,6 +443,23 @@ describe('loadSession — refresh-token flow — REQ-AUTH-002, REQ-AUTH-008', ()
     const result = await loadSession(replayReq, env.DB, SECRET);
     expect(result.user).toBeNull();
 
+    // handleRevokedReplayPath contract: cookiesToSet must clear BOTH
+    // cookies (Max-Age=0) so the browser stops replaying the stolen
+    // refresh value. A regression that swaps unauthenticated(true) for
+    // unauthenticated(false) here would silently leak the stolen cookie
+    // back to the attacker on every subsequent request.
+    expect(result.cookiesToSet.length).toBe(2);
+    expect(
+      result.cookiesToSet.some(
+        (c) => c.startsWith(`${SESSION_COOKIE_NAME}=`) && c.includes('Max-Age=0'),
+      ),
+    ).toBe(true);
+    expect(
+      result.cookiesToSet.some(
+        (c) => c.startsWith(`${REFRESH_TOKEN_COOKIE_NAME}=`) && c.includes('Max-Age=0'),
+      ),
+    ).toBe(true);
+
     // Every refresh row for the user is now revoked, including the
     // second device's row.
     const otherRow = await findRefreshToken(env.DB, otherValue);
@@ -453,6 +470,72 @@ describe('loadSession — refresh-token flow — REQ-AUTH-002, REQ-AUTH-008', ()
       .bind(USER_ID)
       .first<{ session_version: number }>();
     expect(sv!.session_version).toBeGreaterThan(1);
+  });
+
+  it('REQ-AUTH-008: tryRotationPath rate-limit fail-closed returns user=null with EMPTY cookiesToSet (Tier-2 user cap)', async () => {
+    // The user-keyed AUTH_REFRESH_USER limit gates JWT minting inside
+    // the rotation path. When the limit fails closed (KV outage), the
+    // contract is: user=null AND cookiesToSet=[] - the legitimate
+    // user's cookies must survive a transient KV outage. A regression
+    // swapping unauthenticated(false) for unauthenticated(true) here
+    // would clear both cookies on every transient KV blip and force
+    // the user to re-login mid-session.
+    const issueReq = fakeRequest({ ua: 'Mozilla/5.0', country: 'CH' });
+    const { value } = await issueRefreshToken(env.DB, USER_ID, issueReq);
+
+    // Build a KV that throws on every operation so AUTH_REFRESH_USER's
+    // failClosed: true denies the request.
+    const failingKv = {
+      get: () => { throw new Error('kv_outage_simulated'); },
+      put: () => { throw new Error('kv_outage_simulated'); },
+      delete: () => { throw new Error('kv_outage_simulated'); },
+      list: () => { throw new Error('kv_outage_simulated'); },
+    } as unknown as KVNamespace;
+
+    const replayReq = fakeRequest({
+      ua: 'Mozilla/5.0',
+      country: 'CH',
+      cookie: `${REFRESH_TOKEN_COOKIE_NAME}=${value}`,
+    });
+    const result = await loadSession(replayReq, env.DB, SECRET, failingKv);
+    expect(result.user).toBeNull();
+    expect(result.cookiesToSet).toEqual([]);
+
+    // Refresh row must NOT be revoked - this was a transient denial,
+    // not a security event.
+    const stillRow = await findRefreshToken(env.DB, value);
+    expect(stillRow!.revoked_at).toBeNull();
+  });
+
+  it('REQ-AUTH-008: tryGraceWindowPath rate-limit fail-closed returns user=null with EMPTY cookiesToSet (Tier-2 user cap on grace collision)', async () => {
+    // Same fail-closed contract on the grace-collision Tier-2 limit:
+    // a benign concurrent collision that happens to hit a KV outage
+    // must NOT clear cookies (the legitimate user retries; the
+    // collision resolves naturally on the next request).
+    const issueReq = fakeRequest({ ua: 'Mozilla/5.0', country: 'CH' });
+    const { value: oldValue } = await issueRefreshToken(env.DB, USER_ID, issueReq);
+
+    // Set up the grace-collision precondition: revoke the old row by
+    // rotating it (winner just landed), so the loser presenting the
+    // old value falls into the grace branch.
+    const oldRow = await findRefreshToken(env.DB, oldValue);
+    await rotateRefreshToken(env.DB, oldRow!, issueReq);
+
+    const failingKv = {
+      get: () => { throw new Error('kv_outage_simulated'); },
+      put: () => { throw new Error('kv_outage_simulated'); },
+      delete: () => { throw new Error('kv_outage_simulated'); },
+      list: () => { throw new Error('kv_outage_simulated'); },
+    } as unknown as KVNamespace;
+
+    const replayReq = fakeRequest({
+      ua: 'Mozilla/5.0',
+      country: 'CH',
+      cookie: `${REFRESH_TOKEN_COOKIE_NAME}=${oldValue}`,
+    });
+    const result = await loadSession(replayReq, env.DB, SECRET, failingKv);
+    expect(result.user).toBeNull();
+    expect(result.cookiesToSet).toEqual([]);
   });
 
   it('REQ-AUTH-002: empty cookiesToSet on a valid access JWT (no refresh-token DB hit)', async () => {


### PR DESCRIPTION
## Summary

Resolves the two HIGH findings + one MEDIUM that code-reviewer flagged on PR #248 but landed unaddressed.

## H1 - constantTimeEq contradicted its own docstring

\`src/lib/crypto.ts\` header explicitly warns: *\"Constant-time comparison uses Web Crypto's HMAC verify path - a JS-level XOR loop is not a guaranteed constant-time primitive under V8 JIT optimisation.\"* But CF-011 introduced \`constantTimeEq\`, a JS XOR loop, and wired it into the OAuth CSRF state check.

**Fix:** \`step3VerifyCsrfState\` in \`callback.ts\` now calls \`verifyHmacSignature\` (Web Crypto \`subtle.verify\`, constant-time by spec). \`constantTimeEq\` is removed entirely. The rationale in the original CF-011 (\"cookie is server-issued, so HMAC adds no security\") was wrong for *timing* - HMAC verify is the only constant-time primitive in the Web Crypto API for variable-length string equality.

## H2 - missing cookie-clear pin assertions

The four extracted loadSession helpers had no test asserting cookiesToSet on the security-critical branches. A future refactor flipping unauthenticated(true) <-> unauthenticated(false) would not be caught.

Fix:
- refresh-tokens.test.ts reuse-detected (REQ-AUTH-008 AC 4): pin cookiesToSet.length === 2 + verify both clear strings
- New test: tryRotationPath rate-limit fail-closed -> cookiesToSet === []
- New test: tryGraceWindowPath Tier-2 limit fail-closed -> cookiesToSet === []

## M1 - middleware.test.ts cookie length pin

Line 467 was toBeGreaterThan(0). Changed to exact toBe(2) plus refresh-clear string check.

## Test plan
- CI green
- code-reviewer + spec-reviewer triggered by Stop hook on PR-to-main
- OAuth login still works on integration deploy
- No new lint/type errors from constantTimeEq removal