### PR TITLE
feat: route inference through Gemini AI Gateway

### DIFF
--- a/.github/workflows/deploy-integration.yml
+++ b/.github/workflows/deploy-integration.yml
@@ -244,6 +244,18 @@ jobs:
             rm "$TMP"
           done
 
+          # Gemini runs through Cloudflare AI Gateway BYOK. Reuse the
+          # existing deploy token as the Worker runtime gateway token;
+          # never print it, and keep the provider key stored in Gateway.
+          if [ -z "${CLOUDFLARE_API_TOKEN:-}" ]; then
+            echo "::error::Required secret 'CLOUDFLARE_API_TOKEN' is not set."
+            exit 1
+          fi
+          TMP=$(mktemp)
+          printf '%s' "$CLOUDFLARE_API_TOKEN" > "$TMP"
+          npx --yes wrangler secret put CLOUDFLARE_API_TOKEN --env integration < "$TMP"
+          rm "$TMP"
+
           # Sign-in providers — each pair independently optional. Same
           # logic as deploy.yml: at least one must be configured. Per-
           # provider rendering on the landing page reflects which

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -249,6 +249,18 @@ jobs:
             rm "$TMP"
           done
 
+          # Gemini runs through Cloudflare AI Gateway BYOK. Reuse the
+          # existing deploy token as the Worker runtime gateway token;
+          # never print it, and keep the provider key stored in Gateway.
+          if [ -z "${CLOUDFLARE_API_TOKEN:-}" ]; then
+            echo "::error::Required secret 'CLOUDFLARE_API_TOKEN' is not set in the repo."
+            exit 1
+          fi
+          TMP=$(mktemp)
+          printf '%s' "$CLOUDFLARE_API_TOKEN" > "$TMP"
+          npx --yes wrangler secret put CLOUDFLARE_API_TOKEN < "$TMP"
+          rm "$TMP"
+
           # Sign-in providers — each pair is independently optional, but
           # at least ONE complete pair must be set or the app has no way
           # for users to authenticate. Partial pairs (id without secret

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -50,6 +50,11 @@ interface Env {
   // which providers are enabled.
   OAUTH_JWT_SECRET: string;
 
+  // Runtime auth for Cloudflare AI Gateway BYOK. The deploy workflow
+  // pushes the existing GitHub Actions CLOUDFLARE_API_TOKEN secret into
+  // the Worker; the provider key remains stored in AI Gateway.
+  CLOUDFLARE_API_TOKEN?: string;
+
   RESEND_API_KEY: string;
   RESEND_FROM: string;
   APP_URL: string;

--- a/src/lib/dedup-rerank.ts
+++ b/src/lib/dedup-rerank.ts
@@ -158,6 +158,8 @@ async function runOneBatch(
 
   const llmRun = await runJson<BatchPayload>({
     ai: asAiBinding(env.AI),
+    cloudflareApiToken: (env as { CLOUDFLARE_API_TOKEN?: string })
+      .CLOUDFLARE_API_TOKEN,
     params: {
       messages: [
         { role: 'system', content: RERANK_SYSTEM },

--- a/src/lib/discovery.ts
+++ b/src/lib/discovery.ts
@@ -88,6 +88,7 @@ export async function discoverTag(tag: string, env: Env): Promise<DiscoveredFeed
   const userPrompt = discoveryUserPrompt(tag);
   const llmRun = await runJson<LLMDiscoveryPayload>({
     ai: asAiBinding(env.AI),
+    cloudflareApiToken: env.CLOUDFLARE_API_TOKEN,
     params: {
       messages: [
         { role: 'system', content: DISCOVERY_SYSTEM },

--- a/src/lib/generate.ts
+++ b/src/lib/generate.ts
@@ -4,7 +4,7 @@
 // (src/queue/scrape-chunk-consumer.ts).
 
 
-/** Shape Workers AI `.run()` returns. Different models surface token counts
+/** Shape model calls return. Different providers surface token counts
  * under slightly different keys — the reader at the usage site tolerates all
  * the common variants (`usage.input_tokens`, `usage.prompt_tokens`,
  * top-level `tokens_in`). */
@@ -15,6 +15,7 @@ export interface AIRunResponse {
     output_tokens?: number;
     prompt_tokens?: number;
     completion_tokens?: number;
+    total_tokens?: number;
   };
   tokens_in?: number;
   tokens_out?: number;
@@ -28,14 +29,14 @@ interface LLMPayload {
 }
 
 /**
- * Pull the model-produced text out of an `AIRunResponse`. Resolves two
- * shapes across Workers AI's model families:
+ * Pull the model-produced text out of an `AIRunResponse`. Resolves common
+ * shapes across Workers AI and AI Gateway model families:
  *
  *   1. Flat: `{ response: "<JSON string>" | <object> }` — Llama, Mistral,
  *      Kimi, and most other text-generation models.
  *   2. OpenAI envelope: `{ choices: [{ message: { content: "..." } }] }`
- *      — every `@cf/openai/*` endpoint, which proxies OpenAI's
- *      chat-completions API shape directly.
+ *      — every `@cf/openai/*` endpoint and the AI Gateway compat path,
+ *      which proxy the chat-completions API shape directly.
  *
  * Any other shape returns `undefined`, which `parseLLMPayload` then
  * treats as `llm_invalid_json`.
@@ -56,6 +57,19 @@ export function extractResponsePayload(aiResult: AIRunResponse): unknown {
       if (message !== null && message !== undefined && typeof message === 'object') {
         const content = message['content'];
         if (typeof content === 'string') return content;
+        if (Array.isArray(content)) {
+          const text = content
+            .map((part) => {
+              if (typeof part === 'string') return part;
+              if (part !== null && typeof part === 'object') {
+                const value = (part as Record<string, unknown>)['text'];
+                if (typeof value === 'string') return value;
+              }
+              return '';
+            })
+            .join('');
+          if (text !== '') return text;
+        }
         // Reject `null` content (tool-call-only responses) so the
         // caller correctly classifies them as llm_invalid_json instead
         // of silently passing null through the parser.
@@ -258,10 +272,28 @@ export function extractTokensIn(r: AIRunResponse): number {
 
 /** Extract output-token count. Mirrors {@link extractTokensIn}. */
 export function extractTokensOut(r: AIRunResponse): number {
-  if (typeof r.usage?.output_tokens === 'number') return r.usage.output_tokens;
-  if (typeof r.usage?.completion_tokens === 'number')
-    return r.usage.completion_tokens;
-  if (typeof r.tokens_out === 'number') return r.tokens_out;
-  return 0;
+  const visibleOut = (() => {
+    if (typeof r.usage?.output_tokens === 'number') return r.usage.output_tokens;
+    if (typeof r.usage?.completion_tokens === 'number') {
+      return r.usage.completion_tokens;
+    }
+    if (typeof r.tokens_out === 'number') return r.tokens_out;
+    return 0;
+  })();
+
+  // Gemini via AI Gateway can report hidden thinking tokens in
+  // `total_tokens` without including them in `completion_tokens`.
+  // Those tokens are billed as output, so count total - input when it
+  // is larger than the visible output token count.
+  const tokensIn = extractTokensIn(r);
+  if (
+    typeof r.usage?.total_tokens === 'number' &&
+    tokensIn > 0 &&
+    r.usage.total_tokens > tokensIn
+  ) {
+    return Math.max(visibleOut, r.usage.total_tokens - tokensIn);
+  }
+
+  return visibleOut;
 }
 

--- a/src/lib/llm-json.ts
+++ b/src/lib/llm-json.ts
@@ -1,8 +1,8 @@
 // Implements REQ-PIPE-002
 // Implements REQ-PIPE-003
 //
-// Single LLM-call entrypoint used by every Workers-AI site that expects
-// a JSON response (chunk consumer, finalize consumer, discovery).
+// Single LLM-call entrypoint used by every model site that expects
+// a JSON response (chunk consumer, dedup rerank, discovery).
 //
 // Single-model architecture (2026-05-06): the helper runs ONE model
 // per call. The previous primary-then-fallback path (Gemma → 120b)
@@ -46,6 +46,14 @@ export function asAiBinding(ai: unknown): AiBinding {
   return ai as AiBinding;
 }
 
+const AI_GATEWAY_CHAT_COMPLETIONS_URL =
+  'https://gateway.ai.cloudflare.com/v1/ab75f75941a21a81db27bf12e99c620b/ai-news-digest/compat/chat/completions';
+const AI_GATEWAY_MODEL_PREFIXES = ['google-ai-studio/'] as const;
+
+function modelUsesAiGateway(model: string): boolean {
+  return AI_GATEWAY_MODEL_PREFIXES.some((prefix) => model.startsWith(prefix));
+}
+
 export interface AttemptInfo {
   modelUsed: string;
   tokensIn: number;
@@ -76,6 +84,10 @@ export interface RunJsonOptions<T> {
   narrow: (rawResponse: unknown) => T | null;
   /** Optional override; defaults to DEFAULT_MODEL_ID. */
   model?: string;
+  /** Existing Cloudflare API token, reused for AI Gateway auth when set. */
+  cloudflareApiToken?: string;
+  /** Test seam for the AI Gateway HTTP path. */
+  fetchImpl?: typeof fetch;
 }
 
 export async function runJson<T>(
@@ -83,9 +95,9 @@ export async function runJson<T>(
 ): Promise<LlmRunResult<T>> {
   const model = options.model ?? DEFAULT_MODEL_ID;
 
-  // The Workers-AI binding's contract is `Promise<unknown>` because
-  // every model emits a slightly different envelope. The shared
-  // helpers in ~/lib/generate accept the wider AIRunResponse shape
+  // The model-runner boundary is `Promise<unknown>` because every
+  // provider emits a slightly different envelope. The shared helpers
+  // in ~/lib/generate accept the wider AIRunResponse shape
   // (which has an index signature) and gracefully tolerate missing
   // fields, so a single cast at the boundary is safe.
   //
@@ -95,7 +107,7 @@ export async function runJson<T>(
   let result: AIRunResponse | null = null;
   let threwError: string | null = null;
   try {
-    result = (await options.ai.run(model, options.params)) as AIRunResponse;
+    result = (await runModel(model, options)) as AIRunResponse;
   } catch (err) {
     threwError = String(err).slice(0, 500);
   }
@@ -127,6 +139,63 @@ export async function runJson<T>(
       rawResponse: threwError !== null ? { error: threwError } : raw,
     },
   };
+}
+
+async function runModel<T>(
+  model: string,
+  options: RunJsonOptions<T>,
+): Promise<unknown> {
+  const token = options.cloudflareApiToken?.trim();
+  if (token && modelUsesAiGateway(model)) {
+    return runAiGatewayChatCompletion({
+      model,
+      params: options.params,
+      cloudflareApiToken: token,
+      fetchImpl: options.fetchImpl ?? fetch,
+    });
+  }
+
+  return options.ai.run(model, options.params);
+}
+
+async function runAiGatewayChatCompletion(options: {
+  model: string;
+  params: Record<string, unknown>;
+  cloudflareApiToken: string;
+  fetchImpl: typeof fetch;
+}): Promise<unknown> {
+  const response = await options.fetchImpl(AI_GATEWAY_CHAT_COMPLETIONS_URL, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'cf-aig-authorization': `Bearer ${options.cloudflareApiToken}`,
+    },
+    body: JSON.stringify({
+      model: options.model,
+      // Gemini 2.5 Flash enables hidden thinking tokens unless told not
+      // to. The canary needs summary quality, not chain-of-thought spend.
+      reasoning_effort: 'none',
+      ...options.params,
+    }),
+  });
+
+  const bodyText = await response.text();
+  let body: unknown = undefined;
+  if (bodyText !== '') {
+    try {
+      body = JSON.parse(bodyText) as unknown;
+    } catch {
+      body = bodyText;
+    }
+  }
+
+  if (!response.ok) {
+    throw new Error(
+      `AI Gateway HTTP ${response.status}: ${previewRawResponse(body, 500)}`,
+    );
+  }
+
+  return body;
 }
 
 /** Truncate a raw LLM response for log emission so a 50KB JSON dump

--- a/src/lib/llm-json.ts
+++ b/src/lib/llm-json.ts
@@ -85,9 +85,9 @@ export interface RunJsonOptions<T> {
   /** Optional override; defaults to DEFAULT_MODEL_ID. */
   model?: string;
   /** Existing Cloudflare API token, reused for AI Gateway auth when set. */
-  cloudflareApiToken?: string;
+  cloudflareApiToken?: string | undefined;
   /** Test seam for the AI Gateway HTTP path. */
-  fetchImpl?: typeof fetch;
+  fetchImpl?: typeof fetch | undefined;
 }
 
 export async function runJson<T>(

--- a/src/lib/models.ts
+++ b/src/lib/models.ts
@@ -1,11 +1,12 @@
 // Implements REQ-SET-004
 //
-// Hardcoded Workers AI model catalog. The list is the source of truth —
+// Hardcoded inference model catalog. The list is the source of truth —
 // server-side validation (`model_id` must appear in `MODELS`) keys off it,
 // the settings dropdown is rendered from it, and per-digest cost is computed
 // from its per-million-token prices. Updating the catalog is a code edit +
-// deploy; there is no runtime fetch, no KV cache, no Cloudflare API token
-// path. See /sdd/settings.md REQ-SET-004 and REQUIREMENTS.md "Model selection".
+// deploy; there is no runtime fetch or KV cache. Gateway-backed entries use
+// the workflow-provisioned CLOUDFLARE_API_TOKEN secret for runtime auth.
+// See /sdd/settings.md REQ-SET-004 and REQUIREMENTS.md "Model selection".
 //
 // Single-model architecture (2026-05-06): the chunk/finalize/discovery
 // pipelines run one model per call, no fallback. Swapping models means
@@ -34,22 +35,31 @@ export interface ModelOption {
   category: 'featured' | 'budget';
 }
 
-// Default model: @cf/zai-org/glm-4.7-flash. 131K context,
-// low-cost Z.ai instruction model, $0.0605/$0.40 per Mtok. Re-enabled
-// on 2026-06-06 after Gemma failed a full-current-corpus integration
-// refresh with invalid/truncated JSON. This canary keeps the strict
-// one-record-per-input contract and uses smaller chunks to reduce GLM
-// timeout/alignment risk. Do not promote this develop-branch default to
+// Default model: Gemini 2.5 Flash via Cloudflare AI Gateway BYOK.
+// The integration canary uses the OpenAI-compatible AI Gateway endpoint
+// with the existing CLOUDFLARE_API_TOKEN secret for gateway auth; the
+// Google AI Studio provider key is stored in the gateway, not in source
+// or Worker env. Do not promote this develop-branch default to
 // production without a fresh integration scrape proving chunk reliability,
 // JSON validity, summary quality, and same-story dedup quality.
 //
 // This constant is the single source-of-truth for the pipeline's model
 // id (chunk summarisation, rerank, discovery all flow through
 // DEFAULT_MODEL_ID).
-export const DEFAULT_MODEL_ID = '@cf/zai-org/glm-4.7-flash';
+export const DEFAULT_MODEL_ID = 'google-ai-studio/gemini-2.5-flash';
 
 export const MODELS: ModelOption[] = [
   // Featured — headline choices users see at the top of the dropdown.
+  {
+    id: 'google-ai-studio/gemini-2.5-flash',
+    name: 'Gemini 2.5 Flash',
+    description:
+      'Integration canary via Cloudflare AI Gateway BYOK and Google AI Studio. Large context, strong JSON/tool-following candidate for same-quality summarisation.',
+    inputPricePerMtok: 0.30,
+    outputPricePerMtok: 2.50,
+    contextTokens: 1_048_576,
+    category: 'featured',
+  },
   {
     id: '@cf/openai/gpt-oss-120b',
     name: 'GPT OSS 120B',

--- a/src/lib/prompts.ts
+++ b/src/lib/prompts.ts
@@ -19,7 +19,7 @@
  * Shared inference parameters across the LLM calls. Temperature and
  * response_format are identical; only `max_tokens` varies per call
  * site (CF-023): chunk processing produces large multi-article
- * payloads, while finalize and discovery produce tiny JSON envelopes.
+ * payloads, while discovery and rerank produce tiny JSON envelopes.
  *
  * - `temperature: 0.6` — warm enough for the model to pick complete
  *   summaries over minimum-entropy short replies, cool enough for
@@ -34,18 +34,18 @@ const LLM_BASE_PARAMS = {
 
 /**
  * Chunk-prompt OUTPUT budget. The chunk consumer runs `DEFAULT_MODEL_ID`
- * once per chunk (single-model architecture; no fallback). The Workers
- * AI runtime enforces `prompt_tokens + max_tokens ≤ contextTokens`.
- * The current GLM canary has 131K context; the 128K gpt-oss entries
- * remain a useful lower-bound sanity check for rollback. 14K reserves
- * enough headroom for 8 × 100-150 word summaries plus JSON overhead,
- * while reducing the chance that Workers AI keeps a slow model alive
- * writing long, expensive rejected-candidate prose. That leaves ~114K
- * tokens for input on 128K rollback models (~399K chars at ~3.5
- * chars/token), which still comfortably covers the coordinator's
- * greedy chunk packer (`scrape-coordinator.ts:CHUNK_INPUT_CHARS_BUDGET`).
- * Larger-context models simply leave more headroom. User-selected
- * budget models in `MODELS` are never wired here.
+ * once per chunk (single-model architecture; no fallback). Model
+ * runtimes enforce `prompt_tokens + max_tokens ≤ contextTokens`.
+ * The Gemini AI Gateway canary has a much larger context, but the 128K
+ * gpt-oss entries remain a useful lower-bound sanity check for rollback.
+ * 14K reserves enough headroom for 8 × 100-150 word summaries plus JSON
+ * overhead, while reducing the chance that a slow model keeps writing
+ * long, expensive rejected-candidate prose. That leaves ~114K tokens for
+ * input on 128K rollback models (~399K chars at ~3.5 chars/token), which
+ * still comfortably covers the coordinator's greedy chunk packer
+ * (`scrape-coordinator.ts:CHUNK_INPUT_CHARS_BUDGET`). Larger-context
+ * models simply leave more headroom. User-selected budget models in
+ * `MODELS` are never wired here.
  */
 export const CHUNK_LLM_PARAMS = {
   ...LLM_BASE_PARAMS,
@@ -54,7 +54,7 @@ export const CHUNK_LLM_PARAMS = {
 
 /**
  * Discovery-prompt budget — output is `{ feeds: [{ url, name, kind }] }`,
- * usually a handful of entries. Same 4K cap as finalize: small JSON
+ * usually a handful of entries. Same 4K cap as rerank: small JSON
  * envelope, no benefit from the chunk-sized 50K reservation.
  */
 export const DISCOVERY_LLM_PARAMS = {

--- a/src/queue/scrape-chunk-consumer.ts
+++ b/src/queue/scrape-chunk-consumer.ts
@@ -488,6 +488,7 @@ async function runChunkLLM(
 }> {
   const llmRun = await runJson<LLMChunkPayload>({
     ai: asAiBinding(env.AI),
+    cloudflareApiToken: env.CLOUDFLARE_API_TOKEN,
     params: {
       messages: [
         { role: 'system', content: PROCESS_CHUNK_SYSTEM },

--- a/tests/env.d.ts
+++ b/tests/env.d.ts
@@ -22,6 +22,7 @@ declare namespace Cloudflare {
     GOOGLE_OAUTH_CLIENT_ID: string;
     GOOGLE_OAUTH_CLIENT_SECRET: string;
     OAUTH_JWT_SECRET: string;
+    CLOUDFLARE_API_TOKEN?: string;
     RESEND_API_KEY: string;
     RESEND_FROM: string;
     APP_URL: string;

--- a/tests/lib/llm-json.test.ts
+++ b/tests/lib/llm-json.test.ts
@@ -77,6 +77,44 @@ describe('runJson — REQ-PIPE-002 / REQ-PIPE-003', () => {
     expect(result.modelUsed).toBe('custom-model');
   });
 
+  it('REQ-PIPE-002: gateway models use AI Gateway compat instead of AI.run when the token is present', async () => {
+    const ai = makeAi([]);
+    const fetchImpl = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          choices: [{ message: { content: '{"articles": []}' } }],
+          usage: { prompt_tokens: 11, completion_tokens: 13, total_tokens: 40 },
+        }),
+        { status: 200 },
+      ),
+    );
+
+    const result = await runJson({
+      ai,
+      cloudflareApiToken: 'cf-test-token',
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+      params: { messages: [{ role: 'user', content: 'json' }] },
+      narrow: (raw) => (typeof raw === 'string' ? (JSON.parse(raw) as { articles: unknown[] }) : null),
+      model: 'google-ai-studio/gemini-2.5-flash',
+    });
+
+    expect(ai.run).not.toHaveBeenCalled();
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchImpl.mock.calls[0] ?? [];
+    expect(String(url)).toContain('/compat/chat/completions');
+    expect((init as RequestInit).headers).toMatchObject({
+      'cf-aig-authorization': 'Bearer cf-test-token',
+    });
+    expect(JSON.parse(String((init as RequestInit).body))).toMatchObject({
+      model: 'google-ai-studio/gemini-2.5-flash',
+      reasoning_effort: 'none',
+    });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.tokensIn).toBe(11);
+    expect(result.tokensOut).toBe(29);
+  });
+
   it('returns ok=false with a captured error when ai.run throws (e.g. AiError 3046 timeout)', async () => {
     // Workers AI surfaces request-timeouts and capacity errors as
     // thrown AiError objects. The helper must catch the throw and

--- a/tests/lib/models.test.ts
+++ b/tests/lib/models.test.ts
@@ -45,19 +45,18 @@ describe('MODELS catalog', () => {
 });
 
 describe('DEFAULT_MODEL_ID', () => {
-  it('REQ-SET-004: DEFAULT_MODEL_ID is @cf/zai-org/glm-4.7-flash — 131K context, integration canary, single-model arch', () => {
-    // 2026-06-06: retest lower-cost Workers AI options on
-    // develop/integration. Gemma failed JSON reliability on a larger
-    // refresh; GLM is retested with a smaller chunk contract before
-    // any production promotion.
-    expect(DEFAULT_MODEL_ID).toBe('@cf/zai-org/glm-4.7-flash');
+  it('REQ-SET-004: DEFAULT_MODEL_ID is Gemini 2.5 Flash via AI Gateway — integration canary, single-model arch', () => {
+    // 2026-06-07: move the integration canary from direct Workers AI
+    // cheap-model swaps to Cloudflare AI Gateway BYOK + Gemini 2.5
+    // Flash. No production promotion without a fresh integration proof.
+    expect(DEFAULT_MODEL_ID).toBe('google-ai-studio/gemini-2.5-flash');
   });
 
   it('REQ-SET-004: DEFAULT_MODEL_ID is present in MODELS', () => {
     const found = MODELS.find((m) => m.id === DEFAULT_MODEL_ID);
     expect(found).toBeDefined();
     expect(found?.category).toBe('featured');
-    expect(found?.contextTokens).toBeGreaterThanOrEqual(128_000);
+    expect(found?.contextTokens).toBeGreaterThanOrEqual(1_000_000);
   });
 });
 
@@ -77,18 +76,18 @@ describe('modelById', () => {
 
 describe('estimateCost', () => {
   it('REQ-SET-004: estimateCost computes USD from per-million-token prices', () => {
-    // GLM 4.7 Flash: input $0.0605 / output $0.40 per Mtok.
-    // 1,000,000 in -> $0.0605; 1,000,000 out -> $0.40; total $0.4605.
+    // Gemini 2.5 Flash: input $0.30 / output $2.50 per Mtok.
+    // 1,000,000 in -> $0.30; 1,000,000 out -> $2.50; total $2.80.
     const cost = estimateCost(DEFAULT_MODEL_ID, 1_000_000, 1_000_000);
-    expect(cost).toBeCloseTo(0.4605, 6);
+    expect(cost).toBeCloseTo(2.80, 6);
   });
 
   it('REQ-SET-004: estimateCost scales linearly with token counts', () => {
-    // 2,000 input tokens * $0.0605/Mtok = $0.000121
-    // 1,000 output tokens * $0.40/Mtok = $0.000400
-    // total ~= $0.000521
+    // 2,000 input tokens * $0.30/Mtok = $0.000600
+    // 1,000 output tokens * $2.50/Mtok = $0.002500
+    // total ~= $0.003100
     const cost = estimateCost(DEFAULT_MODEL_ID, 2_000, 1_000);
-    expect(cost).toBeCloseTo(0.000521, 9);
+    expect(cost).toBeCloseTo(0.0031, 9);
   });
 
   it('REQ-SET-004: estimateCost is non-zero for Kimi K2.5 (published pricing)', () => {

--- a/tests/pipeline/chunk-consumer.test.ts
+++ b/tests/pipeline/chunk-consumer.test.ts
@@ -280,9 +280,9 @@ describe('scrape-chunk-consumer - REQ-PIPE-002 / REQ-PIPE-015 (chunk robustness)
     expect(chunkCall).toBeDefined();
     const [model, params] = chunkCall as [string, Record<string, unknown>];
     // The chunk LLM model identifier must be a non-empty namespaced
-    // Workers AI binding ID (`@cf/...` or `@hf/...`). A bare empty
-    // string would be a regression: env.AI.run rejects it.
-    expect(model).toMatch(/^@\w+\//);
+    // model ID: Workers AI (`@cf/...`) or AI Gateway provider
+    // (`google-ai-studio/...`). A bare empty string is a regression.
+    expect(model).toMatch(/^(?:@\w+|[a-z0-9-]+)\/.+/);
     const messages = params.messages as Array<{ role: string; content: string }>;
     expect(messages[0]?.role).toBe('system');
     expect(messages[0]?.content).toBe(PROCESS_CHUNK_SYSTEM);


### PR DESCRIPTION
## Summary
- Switch the default inference model to Gemini 2.5 Flash through Cloudflare AI Gateway BYOK.
- Reuse the existing `CLOUDFLARE_API_TOKEN` secret for gateway auth at Worker runtime; the provider key stays in AI Gateway.
- Preserve the single-model/no-fallback architecture and keep chunk summaries at 100-150 words.

## Test plan
- [x] `git diff --check`
- [x] Tiny AI Gateway route probe returned HTTP 200 for `google-ai-studio/gemini-2.5-flash`
- [ ] GitHub Actions PR checks green
- [ ] Integration deploy after merge to develop
- [ ] User-triggered integration refresh validates JSON reliability, quality, cost, and dedup quality