### PR TITLE
fix: bind AI Gateway fetch context

### DIFF
--- a/src/lib/llm-json.ts
+++ b/src/lib/llm-json.ts
@@ -164,20 +164,24 @@ async function runAiGatewayChatCompletion(options: {
   cloudflareApiToken: string;
   fetchImpl: typeof fetch;
 }): Promise<unknown> {
-  const response = await options.fetchImpl(AI_GATEWAY_CHAT_COMPLETIONS_URL, {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-      'cf-aig-authorization': `Bearer ${options.cloudflareApiToken}`,
+  const response = await options.fetchImpl.call(
+    globalThis,
+    AI_GATEWAY_CHAT_COMPLETIONS_URL,
+    {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'cf-aig-authorization': `Bearer ${options.cloudflareApiToken}`,
+      },
+      body: JSON.stringify({
+        model: options.model,
+        // Gemini 2.5 Flash enables hidden thinking tokens unless told not
+        // to. The canary needs summary quality, not chain-of-thought spend.
+        reasoning_effort: 'none',
+        ...options.params,
+      }),
     },
-    body: JSON.stringify({
-      model: options.model,
-      // Gemini 2.5 Flash enables hidden thinking tokens unless told not
-      // to. The canary needs summary quality, not chain-of-thought spend.
-      reasoning_effort: 'none',
-      ...options.params,
-    }),
-  });
+  );
 
   const bodyText = await response.text();
   let body: unknown = undefined;

--- a/tests/lib/llm-json.test.ts
+++ b/tests/lib/llm-json.test.ts
@@ -100,6 +100,7 @@ describe('runJson — REQ-PIPE-002 / REQ-PIPE-003', () => {
 
     expect(ai.run).not.toHaveBeenCalled();
     expect(fetchImpl).toHaveBeenCalledTimes(1);
+    expect(fetchImpl.mock.contexts[0]).toBe(globalThis);
     const [url, init] = fetchImpl.mock.calls[0] ?? [];
     expect(String(url)).toContain('/compat/chat/completions');
     expect((init as RequestInit).headers).toMatchObject({


### PR DESCRIPTION
## Summary
- Fix AI Gateway HTTP calls in Workers by invoking `fetch` with `globalThis` as the receiver.
- Add a regression assertion for the Gateway fetch call context.

## Test plan
- [x] `git diff --check`
- [ ] GitHub Actions PR checks green
- [ ] Redeploy integration and watch chunk logs for successful Gemini calls