### PR TITLE
feat: test Gemini Flash-Lite canary

### DIFF
--- a/src/lib/dedup-rerank.ts
+++ b/src/lib/dedup-rerank.ts
@@ -31,6 +31,7 @@
 // classification accuracy on a smaller model does not degrade from
 // attention dilution.
 
+import { parseLLMJson } from '~/lib/generate';
 import { runJson, asAiBinding } from '~/lib/llm-json';
 import { log } from '~/lib/log';
 
@@ -98,17 +99,9 @@ interface BatchPayload {
 }
 
 function narrowBatchPayload(raw: unknown): BatchPayload | null {
-  if (raw === null || raw === undefined) return null;
-  if (typeof raw === 'string') {
-    if (raw === '') return null;
-    try {
-      return JSON.parse(raw) as BatchPayload;
-    } catch {
-      return null;
-    }
-  }
-  if (typeof raw === 'object') return raw as BatchPayload;
-  return null;
+  const parsed = parseLLMJson(raw);
+  if (parsed === null) return null;
+  return parsed as BatchPayload;
 }
 
 const RERANK_SYSTEM = [
@@ -166,6 +159,8 @@ async function runOneBatch(
         { role: 'user', content: buildBatchUser(pairs) },
       ],
       temperature: 0,
+      response_format: { type: 'json_object' },
+      max_tokens: 2_000,
     },
     narrow: (raw) => narrowBatchPayload(raw),
   }).catch((err: unknown) => {

--- a/src/lib/models.ts
+++ b/src/lib/models.ts
@@ -35,26 +35,38 @@ export interface ModelOption {
   category: 'featured' | 'budget';
 }
 
-// Default model: Gemini 2.5 Flash via Cloudflare AI Gateway BYOK.
+// Default model: Gemini 2.5 Flash-Lite via Cloudflare AI Gateway BYOK.
 // The integration canary uses the OpenAI-compatible AI Gateway endpoint
 // with the existing CLOUDFLARE_API_TOKEN secret for gateway auth; the
 // Google AI Studio provider key is stored in the gateway, not in source
-// or Worker env. Do not promote this develop-branch default to
-// production without a fresh integration scrape proving chunk reliability,
-// JSON validity, summary quality, and same-story dedup quality.
+// or Worker env. Flash-Lite is the lower-cost Gemini canary after
+// Gemini 2.0 Flash returned "no longer available" from Google AI
+// Studio. Do not promote this develop-branch default to production
+// without a fresh integration scrape proving chunk reliability, JSON
+// validity, summary quality, and same-story dedup quality.
 //
 // This constant is the single source-of-truth for the pipeline's model
 // id (chunk summarisation, rerank, discovery all flow through
 // DEFAULT_MODEL_ID).
-export const DEFAULT_MODEL_ID = 'google-ai-studio/gemini-2.5-flash';
+export const DEFAULT_MODEL_ID = 'google-ai-studio/gemini-2.5-flash-lite';
 
 export const MODELS: ModelOption[] = [
   // Featured — headline choices users see at the top of the dropdown.
   {
+    id: 'google-ai-studio/gemini-2.5-flash-lite',
+    name: 'Gemini 2.5 Flash-Lite',
+    description:
+      'Lower-cost Gemini integration canary via Cloudflare AI Gateway BYOK and Google AI Studio. Current replacement for unavailable Gemini 2.0 Flash.',
+    inputPricePerMtok: 0.10,
+    outputPricePerMtok: 0.40,
+    contextTokens: 1_048_576,
+    category: 'featured',
+  },
+  {
     id: 'google-ai-studio/gemini-2.5-flash',
     name: 'Gemini 2.5 Flash',
     description:
-      'Integration canary via Cloudflare AI Gateway BYOK and Google AI Studio. Large context, strong JSON/tool-following candidate for same-quality summarisation.',
+      'Higher-output-cost Gemini AI Gateway model. Completed integration mechanically but missed the 70% savings target.',
     inputPricePerMtok: 0.30,
     outputPricePerMtok: 2.50,
     contextTokens: 1_048_576,

--- a/tests/lib/dedup-rerank.test.ts
+++ b/tests/lib/dedup-rerank.test.ts
@@ -142,6 +142,23 @@ describe('rerankBorderlinePairsBatch - REQ-PIPE-009 (AD48 batched API)', () => {
     expect((env.AI as unknown as { run: ReturnType<typeof vi.fn> }).run).toHaveBeenCalledTimes(2);
   });
 
+  it('tolerates fenced JSON with prose around the rerank verdicts', async () => {
+    const env = makeAi({
+      response: 'Here is the JSON:\n```json\n{"verdicts":[{"i":0,"same_event":true}]}\n```',
+    });
+    const verdicts = await rerankBorderlinePairsBatch(env, [pair(0, true)]);
+    expect(verdicts).toEqual([true]);
+  });
+
+  it('requests JSON mode and a bounded output budget for rerank calls', async () => {
+    const env = makeAi(verdictResponse([{ i: 0, same_event: true }]));
+    await rerankBorderlinePairsBatch(env, [pair(0, true)]);
+    const run = (env.AI as unknown as { run: ReturnType<typeof vi.fn> }).run;
+    const params = run.mock.calls[0]?.[1] as Record<string, unknown>;
+    expect(params.response_format).toEqual({ type: 'json_object' });
+    expect(params.max_tokens).toBe(2_000);
+  });
+
   it('returns all-false for a batch when the LLM emits unparseable JSON', async () => {
     const env = makeAi({ response: 'not-json' });
     const verdicts = await rerankBorderlinePairsBatch(env, [

--- a/tests/lib/models.test.ts
+++ b/tests/lib/models.test.ts
@@ -45,11 +45,12 @@ describe('MODELS catalog', () => {
 });
 
 describe('DEFAULT_MODEL_ID', () => {
-  it('REQ-SET-004: DEFAULT_MODEL_ID is Gemini 2.5 Flash via AI Gateway — integration canary, single-model arch', () => {
-    // 2026-06-07: move the integration canary from direct Workers AI
-    // cheap-model swaps to Cloudflare AI Gateway BYOK + Gemini 2.5
-    // Flash. No production promotion without a fresh integration proof.
-    expect(DEFAULT_MODEL_ID).toBe('google-ai-studio/gemini-2.5-flash');
+  it('REQ-SET-004: DEFAULT_MODEL_ID is Gemini 2.5 Flash-Lite via AI Gateway — integration canary, single-model arch', () => {
+    // 2026-06-07: Gemini 2.0 Flash is no longer available through
+    // Google AI Studio, so test the current low-cost Gateway canary:
+    // Gemini 2.5 Flash-Lite. No production promotion without a fresh
+    // integration proof.
+    expect(DEFAULT_MODEL_ID).toBe('google-ai-studio/gemini-2.5-flash-lite');
   });
 
   it('REQ-SET-004: DEFAULT_MODEL_ID is present in MODELS', () => {
@@ -76,18 +77,18 @@ describe('modelById', () => {
 
 describe('estimateCost', () => {
   it('REQ-SET-004: estimateCost computes USD from per-million-token prices', () => {
-    // Gemini 2.5 Flash: input $0.30 / output $2.50 per Mtok.
-    // 1,000,000 in -> $0.30; 1,000,000 out -> $2.50; total $2.80.
+    // Gemini 2.5 Flash-Lite: input $0.10 / output $0.40 per Mtok.
+    // 1,000,000 in -> $0.10; 1,000,000 out -> $0.40; total $0.50.
     const cost = estimateCost(DEFAULT_MODEL_ID, 1_000_000, 1_000_000);
-    expect(cost).toBeCloseTo(2.80, 6);
+    expect(cost).toBeCloseTo(0.50, 6);
   });
 
   it('REQ-SET-004: estimateCost scales linearly with token counts', () => {
-    // 2,000 input tokens * $0.30/Mtok = $0.000600
-    // 1,000 output tokens * $2.50/Mtok = $0.002500
-    // total ~= $0.003100
+    // 2,000 input tokens * $0.10/Mtok = $0.000200
+    // 1,000 output tokens * $0.40/Mtok = $0.000400
+    // total ~= $0.000600
     const cost = estimateCost(DEFAULT_MODEL_ID, 2_000, 1_000);
-    expect(cost).toBeCloseTo(0.0031, 9);
+    expect(cost).toBeCloseTo(0.0006, 9);
   });
 
   it('REQ-SET-004: estimateCost is non-zero for Kimi K2.5 (published pricing)', () => {


### PR DESCRIPTION
## Summary
- Switch the Gateway canary default to `google-ai-studio/gemini-2.5-flash-lite` because Gemini 2.0 Flash is no longer available through Google AI Studio.
- Keep chunk sizing unchanged for an apples-to-apples next run.
- Harden borderline dedup rerank JSON parsing and request JSON mode with a bounded output budget.

## Test plan
- [x] `git diff --check`
- [x] Gateway probe for `google-ai-studio/gemini-2.5-flash-lite` returned HTTP 200
- [ ] GitHub Actions PR checks green
- [ ] Merge to develop and deploy integration after green CI
- [ ] User-triggered refresh validates cost, JSON reliability, summary quality, and dedup quality