### PR TITLE
feat: tune Flash-Lite canary telemetry

### DIFF
--- a/src/lib/dedup-rerank.ts
+++ b/src/lib/dedup-rerank.ts
@@ -153,6 +153,12 @@ async function runOneBatch(
     ai: asAiBinding(env.AI),
     cloudflareApiToken: (env as { CLOUDFLARE_API_TOKEN?: string })
       .CLOUDFLARE_API_TOKEN,
+    metadata: {
+      purpose: 'dedup_rerank',
+      pair_count: pairs.length,
+      first_pair_a: pairs[0]?.a.id ?? '',
+      first_pair_b: pairs[0]?.b.id ?? '',
+    },
     params: {
       messages: [
         { role: 'system', content: RERANK_SYSTEM },

--- a/src/lib/discovery.ts
+++ b/src/lib/discovery.ts
@@ -89,6 +89,10 @@ export async function discoverTag(tag: string, env: Env): Promise<DiscoveredFeed
   const llmRun = await runJson<LLMDiscoveryPayload>({
     ai: asAiBinding(env.AI),
     cloudflareApiToken: env.CLOUDFLARE_API_TOKEN,
+    metadata: {
+      purpose: 'discovery',
+      tag,
+    },
     params: {
       messages: [
         { role: 'system', content: DISCOVERY_SYSTEM },

--- a/src/lib/llm-json.ts
+++ b/src/lib/llm-json.ts
@@ -84,6 +84,8 @@ export interface RunJsonOptions<T> {
   narrow: (rawResponse: unknown) => T | null;
   /** Optional override; defaults to DEFAULT_MODEL_ID. */
   model?: string;
+  /** Up to five AI Gateway metadata entries for log correlation. */
+  metadata?: Record<string, string | number | boolean> | undefined;
   /** Existing Cloudflare API token, reused for AI Gateway auth when set. */
   cloudflareApiToken?: string | undefined;
   /** Test seam for the AI Gateway HTTP path. */
@@ -150,6 +152,7 @@ async function runModel<T>(
     return runAiGatewayChatCompletion({
       model,
       params: options.params,
+      metadata: options.metadata,
       cloudflareApiToken: token,
       fetchImpl: options.fetchImpl ?? fetch,
     });
@@ -161,6 +164,7 @@ async function runModel<T>(
 async function runAiGatewayChatCompletion(options: {
   model: string;
   params: Record<string, unknown>;
+  metadata?: Record<string, string | number | boolean> | undefined;
   cloudflareApiToken: string;
   fetchImpl: typeof fetch;
 }): Promise<unknown> {
@@ -172,6 +176,9 @@ async function runAiGatewayChatCompletion(options: {
       headers: {
         'Content-Type': 'application/json',
         'cf-aig-authorization': `Bearer ${options.cloudflareApiToken}`,
+        ...(options.metadata !== undefined
+          ? { 'cf-aig-metadata': JSON.stringify(options.metadata) }
+          : {}),
       },
       body: JSON.stringify({
         model: options.model,

--- a/src/lib/prompts.ts
+++ b/src/lib/prompts.ts
@@ -104,8 +104,10 @@ LENGTH — 100 to 150 WORDS (NON-NEGOTIABLE CONTRACT):
     HOW paragraphs with concrete grounded facts — never pad with
     filler, never repeat, but never cut short either.
   - Maximum 150 words. Do not exceed.
-  - Truncated outputs are rejected server-side as malformed. Your
-    target is 100-150; aim for the middle of that range.
+  - Truncated outputs are rejected server-side as malformed. In
+    practice, write 120-135 words for every non-drop article. The
+    100-word minimum is a floor, not a target; 88-99 word summaries
+    are invalid and must be expanded before you return JSON.
 
 STRUCTURE — 2 to 3 PARAGRAPHS:
 
@@ -229,7 +231,7 @@ Return JSON:
     {
       "index": 0,
       "title": "punchy NYT-style headline, 45-80 characters, about candidate [0] specifically",
-      "details": "2 paragraphs of 2-4 sentences each, 100-150 words total, separated by \\n (WHAT happened / HOW it works / optional IMPACT for the reader) — grounded in candidate [0]'s snippet only, every claim traceable to a single passage, distinctive mechanism named; for dropped candidates use an empty string",
+      "details": "2 paragraphs of 2-4 sentences each, 100-150 words total, ideally 120-135 words, separated by \\n (WHAT happened / HOW it works / optional IMPACT for the reader) — grounded in candidate [0]'s snippet only, every claim traceable to a single passage, distinctive mechanism named; for dropped candidates use an empty string",
       "tags": ["only tags from the allowlist above"]
     }
   ]

--- a/src/queue/scrape-chunk-consumer.ts
+++ b/src/queue/scrape-chunk-consumer.ts
@@ -145,6 +145,14 @@ export async function handleChunkBatch(
       // timed out, run.status flipped to 'failed').
       const completed = await countChunkCompletions(env.DB, body.scrape_run_id);
       const finalStatus: 'ready' | 'failed' = completed > 0 ? 'ready' : 'failed';
+      log('warn', 'digest.generation', {
+        status: 'chunk_terminal_failure_rescue',
+        scrape_run_id: body.scrape_run_id,
+        chunk_index: body.chunk_index,
+        completed_chunks: completed,
+        total_chunks: body.total_chunks,
+        final_status: finalStatus,
+      });
       await finishRun(env.DB, body.scrape_run_id, finalStatus);
       if (finalStatus === 'failed') {
         // CF-001: no finalize will run for this scrape_run; stamp the
@@ -328,11 +336,11 @@ export async function processOneChunk(
   await upsertVectors(env, prepared, body);
 
   // Record completion + conditionally enqueue finalize.
-  // `completedCount` is returned for the chunk-status API (status route reads
-  // it from D1 directly) but not consumed here, hence the leading underscore.
+  // `completedCount` is logged so live tails can prove whether each chunk
+  // advanced the D1 completion ledger.
   const {
     isFirstCompletion,
-    completedCount: _completedCount,
+    completedCount,
   } = await recordChunkCompletionAndCheckFinalize(env, body);
 
   const tokensIn = llmRun.tokensIn;
@@ -360,6 +368,8 @@ export async function processOneChunk(
     scrape_run_id: body.scrape_run_id,
     chunk_index: body.chunk_index,
     total_chunks: body.total_chunks,
+    completed_chunks: completedCount,
+    first_completion: isFirstCompletion,
     articles_ingested: articlesIngested,
     articles_deduped: articlesDeduped,
     tokens_in: tokensIn,
@@ -489,6 +499,12 @@ async function runChunkLLM(
   const llmRun = await runJson<LLMChunkPayload>({
     ai: asAiBinding(env.AI),
     cloudflareApiToken: env.CLOUDFLARE_API_TOKEN,
+    metadata: {
+      purpose: 'scrape_chunk',
+      scrape_run_id: body.scrape_run_id,
+      chunk_index: body.chunk_index,
+      total_chunks: body.total_chunks,
+    },
     params: {
       messages: [
         { role: 'system', content: PROCESS_CHUNK_SYSTEM },

--- a/src/queue/scrape-coordinator.ts
+++ b/src/queue/scrape-coordinator.ts
@@ -90,10 +90,15 @@ function applyPreferDirectOverGoogleNews(
 //      that title-overlap-dropped against 60 input candidates.
 // A residual 5-candidate chunk in the same run produced 3 articles
 // with `alignment_mode: echoed_index` (60% yield), confirming the
-// model handles small batches correctly. 2026-06 GLM retest uses 8
+// model handles small batches correctly. 2026-06 GLM retest used 8
 // because GLM/Gemma canaries showed missing-index, timeout, and JSON
 // reliability failures even when the pipeline wait cap was fixed.
-const MAX_CANDIDATES_PER_CHUNK = 8;
+// Gemini Flash-Lite handled 11 chunk calls in 6.8-9.8s with valid
+// Gateway responses on the 2026-06-07 integration canary, so the next
+// canary raises the count cap to 12 while keeping the char budget
+// unchanged. This reduces repeated prompt overhead and queue surface
+// area without approaching the model context limit.
+const MAX_CANDIDATES_PER_CHUNK = 12;
 
 /** Greedy chunk-packer character budget. The chunk consumer runs the
  * single default model (see DEFAULT_MODEL_ID); the context window is

--- a/tests/lib/llm-json.test.ts
+++ b/tests/lib/llm-json.test.ts
@@ -93,6 +93,12 @@ describe('runJson — REQ-PIPE-002 / REQ-PIPE-003', () => {
       ai,
       cloudflareApiToken: 'cf-test-token',
       fetchImpl: fetchImpl as unknown as typeof fetch,
+      metadata: {
+        purpose: 'scrape_chunk',
+        scrape_run_id: 'run-1',
+        chunk_index: 2,
+        total_chunks: 4,
+      },
       params: { messages: [{ role: 'user', content: 'json' }] },
       narrow: (raw) => (typeof raw === 'string' ? (JSON.parse(raw) as { articles: unknown[] }) : null),
       model: 'google-ai-studio/gemini-2.5-flash',
@@ -105,6 +111,12 @@ describe('runJson — REQ-PIPE-002 / REQ-PIPE-003', () => {
     expect(String(url)).toContain('/compat/chat/completions');
     expect((init as RequestInit).headers).toMatchObject({
       'cf-aig-authorization': 'Bearer cf-test-token',
+      'cf-aig-metadata': JSON.stringify({
+        purpose: 'scrape_chunk',
+        scrape_run_id: 'run-1',
+        chunk_index: 2,
+        total_chunks: 4,
+      }),
     });
     expect(JSON.parse(String((init as RequestInit).body))).toMatchObject({
       model: 'google-ai-studio/gemini-2.5-flash',

--- a/tests/pipeline/chunk-packer.test.ts
+++ b/tests/pipeline/chunk-packer.test.ts
@@ -78,12 +78,12 @@ describe('packCandidatesIntoChunks (REQ-PIPE-001)', () => {
     expect(chunks.map((c) => c.length)).toEqual([100, 100]);
   });
 
-  it('uses the GLM canary default count cap of 8 candidates', () => {
-    const candidates = Array.from({ length: 40 }, (_, i) =>
+  it('uses the Flash-Lite canary default count cap of 12 candidates', () => {
+    const candidates = Array.from({ length: 48 }, (_, i) =>
       makeCandidate({ canonical_url: `https://example.com/${i}` }),
     );
     const chunks = packCandidatesIntoChunks(candidates, 10_000_000);
-    expect(chunks.map((c) => c.length)).toEqual([8, 8, 8, 8, 8]);
+    expect(chunks.map((c) => c.length)).toEqual([12, 12, 12, 12]);
   });
 
   it('packs thin candidates up to the budget cap (280K) when budget binds first', () => {


### PR DESCRIPTION
## Summary
- add AI Gateway metadata headers for chunk/discovery/rerank log correlation
- raise Flash-Lite chunk cap from 8 to 12 for the next integration canary
- strengthen the summary prompt toward 120–135 words and add chunk completion telemetry

## Test plan
- [ ] CI green on this PR
- [ ] Deploy integration after CI, reset dataset to 241-row baseline, and rerun canary with live Worker tail