### PR TITLE
fix: avoid cached malformed Gateway responses

### DIFF
--- a/src/lib/llm-json.ts
+++ b/src/lib/llm-json.ts
@@ -176,6 +176,11 @@ async function runAiGatewayChatCompletion(options: {
       headers: {
         'Content-Type': 'application/json',
         'cf-aig-authorization': `Bearer ${options.cloudflareApiToken}`,
+        // Dynamic scrape chunks are retry-sensitive: if the model returns
+        // malformed JSON once, serving that same cached body makes every
+        // queue retry fail immediately. Always ask Gateway for a fresh
+        // provider response.
+        'cf-aig-skip-cache': 'true',
         ...(options.metadata !== undefined
           ? { 'cf-aig-metadata': JSON.stringify(options.metadata) }
           : {}),

--- a/src/queue/scrape-coordinator.ts
+++ b/src/queue/scrape-coordinator.ts
@@ -93,12 +93,12 @@ function applyPreferDirectOverGoogleNews(
 // model handles small batches correctly. 2026-06 GLM retest used 8
 // because GLM/Gemma canaries showed missing-index, timeout, and JSON
 // reliability failures even when the pipeline wait cap was fixed.
-// Gemini Flash-Lite handled 11 chunk calls in 6.8-9.8s with valid
-// Gateway responses on the 2026-06-07 integration canary, so the next
-// canary raises the count cap to 12 while keeping the char budget
-// unchanged. This reduces repeated prompt overhead and queue surface
-// area without approaching the model context limit.
-const MAX_CANDIDATES_PER_CHUNK = 12;
+// Gemini Flash-Lite handled 8-candidate chunks reliably on the
+// 2026-06-07 integration canary (11/11 completed, 0 invalid JSON).
+// A follow-up 12-candidate canary reduced fan-out to 7 chunks but
+// produced malformed JSON and failed the scrape, so keep the cap at 8
+// until a larger-batch prompt can prove JSON reliability.
+const MAX_CANDIDATES_PER_CHUNK = 8;
 
 /** Greedy chunk-packer character budget. The chunk consumer runs the
  * single default model (see DEFAULT_MODEL_ID); the context window is

--- a/tests/lib/llm-json.test.ts
+++ b/tests/lib/llm-json.test.ts
@@ -111,6 +111,7 @@ describe('runJson — REQ-PIPE-002 / REQ-PIPE-003', () => {
     expect(String(url)).toContain('/compat/chat/completions');
     expect((init as RequestInit).headers).toMatchObject({
       'cf-aig-authorization': 'Bearer cf-test-token',
+      'cf-aig-skip-cache': 'true',
       'cf-aig-metadata': JSON.stringify({
         purpose: 'scrape_chunk',
         scrape_run_id: 'run-1',

--- a/tests/pipeline/chunk-packer.test.ts
+++ b/tests/pipeline/chunk-packer.test.ts
@@ -78,12 +78,12 @@ describe('packCandidatesIntoChunks (REQ-PIPE-001)', () => {
     expect(chunks.map((c) => c.length)).toEqual([100, 100]);
   });
 
-  it('uses the Flash-Lite canary default count cap of 12 candidates', () => {
-    const candidates = Array.from({ length: 48 }, (_, i) =>
+  it('uses the Flash-Lite reliable default count cap of 8 candidates', () => {
+    const candidates = Array.from({ length: 40 }, (_, i) =>
       makeCandidate({ canonical_url: `https://example.com/${i}` }),
     );
     const chunks = packCandidatesIntoChunks(candidates, 10_000_000);
-    expect(chunks.map((c) => c.length)).toEqual([12, 12, 12, 12]);
+    expect(chunks.map((c) => c.length)).toEqual([8, 8, 8, 8, 8]);
   });
 
   it('packs thin candidates up to the budget cap (280K) when budget binds first', () => {


### PR DESCRIPTION
## Summary
- restore Flash-Lite chunk cap to the last reliable value of 8 after the 12-candidate canary failed JSON reliability
- send `cf-aig-skip-cache: true` on AI Gateway calls so malformed JSON is not replayed on queue retry
- keep Gateway metadata and chunk completion telemetry from the prior canary patch

## Test plan
- [ ] CI green on this PR
- [ ] Deploy integration after CI, reset dataset to the 241-row baseline, and rerun canary with live Worker tail