### PR TITLE
Fix Wrangler secret cleanup in deploy

### DIFF
--- a/.github/workflows/deploy-integration.yml
+++ b/.github/workflows/deploy-integration.yml
@@ -307,22 +307,12 @@ jobs:
             rm "$TMP"
           done
           LEGACY_SECRET_LIST=$(mktemp)
-          if ! npx --yes wrangler secret list --env integration --json > "$LEGACY_SECRET_LIST"; then
+          if ! npx --yes wrangler secret list --env integration > "$LEGACY_SECRET_LIST"; then
             echo "::error::Failed to list integration Worker secrets before clearing legacy CLOUDFLARE_API_TOKEN."
             rm -f "$LEGACY_SECRET_LIST"
             exit 1
           fi
-          if ! LEGACY_SECRET_PRESENT=$(node - "$LEGACY_SECRET_LIST" <<'NODE'
-          const fs = require('fs');
-          const secrets = JSON.parse(fs.readFileSync(process.argv[2], 'utf8'));
-          console.log(secrets.some((secret) => secret.name === 'CLOUDFLARE_API_TOKEN') ? 'yes' : 'no');
-          NODE
-          ); then
-            echo "::error::Failed to parse integration Worker secret list before clearing legacy CLOUDFLARE_API_TOKEN."
-            rm -f "$LEGACY_SECRET_LIST"
-            exit 1
-          fi
-          if [ "$LEGACY_SECRET_PRESENT" = "yes" ]; then
+          if grep -Eq '(^|[[:space:]])CLOUDFLARE_API_TOKEN($|[[:space:]])' "$LEGACY_SECRET_LIST"; then
             npx --yes wrangler secret delete CLOUDFLARE_API_TOKEN --env integration --force
           else
             echo "CLOUDFLARE_API_TOKEN not set on integration Worker — nothing to clear"

--- a/.github/workflows/deploy-integration.yml
+++ b/.github/workflows/deploy-integration.yml
@@ -307,12 +307,22 @@ jobs:
             rm "$TMP"
           done
           LEGACY_SECRET_LIST=$(mktemp)
-          if ! npx --yes wrangler secret list --env integration > "$LEGACY_SECRET_LIST"; then
+          if ! npx --yes wrangler secret list --env integration --format json > "$LEGACY_SECRET_LIST"; then
             echo "::error::Failed to list integration Worker secrets before clearing legacy CLOUDFLARE_API_TOKEN."
             rm -f "$LEGACY_SECRET_LIST"
             exit 1
           fi
-          if grep -Eq '(^|[[:space:]])CLOUDFLARE_API_TOKEN($|[[:space:]])' "$LEGACY_SECRET_LIST"; then
+          if ! LEGACY_SECRET_PRESENT=$(node - "$LEGACY_SECRET_LIST" <<'NODE'
+          const fs = require('fs');
+          const secrets = JSON.parse(fs.readFileSync(process.argv[2], 'utf8'));
+          console.log(secrets.some((secret) => secret.name === 'CLOUDFLARE_API_TOKEN') ? 'yes' : 'no');
+          NODE
+          ); then
+            echo "::error::Failed to parse integration Worker secret list before clearing legacy CLOUDFLARE_API_TOKEN."
+            rm -f "$LEGACY_SECRET_LIST"
+            exit 1
+          fi
+          if [ "$LEGACY_SECRET_PRESENT" = "yes" ]; then
             npx --yes wrangler secret delete CLOUDFLARE_API_TOKEN --env integration --force
           else
             echo "CLOUDFLARE_API_TOKEN not set on integration Worker — nothing to clear"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -312,12 +312,22 @@ jobs:
             rm "$TMP"
           done
           LEGACY_SECRET_LIST=$(mktemp)
-          if ! npx --yes wrangler secret list > "$LEGACY_SECRET_LIST"; then
+          if ! npx --yes wrangler secret list --format json > "$LEGACY_SECRET_LIST"; then
             echo "::error::Failed to list Worker secrets before clearing legacy CLOUDFLARE_API_TOKEN."
             rm -f "$LEGACY_SECRET_LIST"
             exit 1
           fi
-          if grep -Eq '(^|[[:space:]])CLOUDFLARE_API_TOKEN($|[[:space:]])' "$LEGACY_SECRET_LIST"; then
+          if ! LEGACY_SECRET_PRESENT=$(node - "$LEGACY_SECRET_LIST" <<'NODE'
+          const fs = require('fs');
+          const secrets = JSON.parse(fs.readFileSync(process.argv[2], 'utf8'));
+          console.log(secrets.some((secret) => secret.name === 'CLOUDFLARE_API_TOKEN') ? 'yes' : 'no');
+          NODE
+          ); then
+            echo "::error::Failed to parse Worker secret list before clearing legacy CLOUDFLARE_API_TOKEN."
+            rm -f "$LEGACY_SECRET_LIST"
+            exit 1
+          fi
+          if [ "$LEGACY_SECRET_PRESENT" = "yes" ]; then
             npx --yes wrangler secret delete CLOUDFLARE_API_TOKEN --force
           else
             echo "CLOUDFLARE_API_TOKEN not set on Worker — nothing to clear"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -312,22 +312,12 @@ jobs:
             rm "$TMP"
           done
           LEGACY_SECRET_LIST=$(mktemp)
-          if ! npx --yes wrangler secret list --json > "$LEGACY_SECRET_LIST"; then
+          if ! npx --yes wrangler secret list > "$LEGACY_SECRET_LIST"; then
             echo "::error::Failed to list Worker secrets before clearing legacy CLOUDFLARE_API_TOKEN."
             rm -f "$LEGACY_SECRET_LIST"
             exit 1
           fi
-          if ! LEGACY_SECRET_PRESENT=$(node - "$LEGACY_SECRET_LIST" <<'NODE'
-          const fs = require('fs');
-          const secrets = JSON.parse(fs.readFileSync(process.argv[2], 'utf8'));
-          console.log(secrets.some((secret) => secret.name === 'CLOUDFLARE_API_TOKEN') ? 'yes' : 'no');
-          NODE
-          ); then
-            echo "::error::Failed to parse Worker secret list before clearing legacy CLOUDFLARE_API_TOKEN."
-            rm -f "$LEGACY_SECRET_LIST"
-            exit 1
-          fi
-          if [ "$LEGACY_SECRET_PRESENT" = "yes" ]; then
+          if grep -Eq '(^|[[:space:]])CLOUDFLARE_API_TOKEN($|[[:space:]])' "$LEGACY_SECRET_LIST"; then
             npx --yes wrangler secret delete CLOUDFLARE_API_TOKEN --force
           else
             echo "CLOUDFLARE_API_TOKEN not set on Worker — nothing to clear"


### PR DESCRIPTION
## Summary
- Fix production Deploy after Wrangler 4.98 rejected `wrangler secret list --json`.
- Use supported text output from `wrangler secret list` and grep for the legacy `CLOUDFLARE_API_TOKEN` Worker secret before deleting it.
- Apply the same compatibility fix to the integration deploy workflow.

## SDD / docs
- No requirement or documentation behavior changed; deploy still clears any legacy Worker `CLOUDFLARE_API_TOKEN` secret as documented.

## Test plan
- [x] `git diff --check`
- [ ] PR Checks green on this PR
- [ ] Extension-governed PR-boundary review completes with no blocking findings
- [ ] Production Deploy re-run/merge verifies the fixed secret cleanup path